### PR TITLE
Add minimal dev tools.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,59 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.5.0
+    hooks:
+      - id: check-added-large-files
+      - id: check-json
+        exclude: asv.conf.json
+      - id: check-merge-conflict
+      - id: check-toml
+      - id: check-yaml
+        exclude: conda/meta.yaml
+      - id: detect-private-key
+      - id: trailing-whitespace
+        args: [ --markdown-linebreak-ext=md ]
+        exclude: '\.svg'
+  - repo: https://github.com/pycqa/isort
+    rev: 5.12.0
+    hooks:
+      - id: isort
+        name: isort (python)
+  - repo: https://github.com/psf/black-pre-commit-mirror
+    rev: 23.11.0
+    hooks:
+      - id: black
+  - repo: https://github.com/kynan/nbstripout
+    rev: 0.6.0
+    hooks:
+      - id: nbstripout
+        types: [ "jupyter" ]
+        args: [ "--drop-empty-cells",
+                "--extra-keys 'metadata.language_info.version cell.metadata.jp-MarkdownHeadingCollapsed cell.metadata.pycharm'" ]
+  - repo: https://github.com/pycqa/flake8
+    rev: 6.1.0
+    hooks:
+      - id: flake8
+        types: ["python"]
+        additional_dependencies: ["flake8-bugbear==23.9.16"]
+  - repo: https://github.com/pycqa/bandit
+    rev: 1.7.5
+    hooks:
+      - id: bandit
+        additional_dependencies: ["bandit[toml]"]
+        args: ["-c", "pyproject.toml"]
+  - repo: https://github.com/codespell-project/codespell
+    rev: v2.2.6
+    hooks:
+      - id: codespell
+        additional_dependencies:
+          - tomli
+  - repo: https://github.com/pre-commit/pygrep-hooks
+    rev: v1.10.0
+    hooks:
+      - id: python-no-eval
+      - id: python-no-log-warn
+      - id: python-use-type-annotations
+      - id: rst-backticks
+      - id: rst-directive-colons
+      - id: rst-inline-touching-normal
+      - id: text-unicode-replacement-char

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,6 +35,7 @@ repos:
       - id: flake8
         types: ["python"]
         additional_dependencies: ["flake8-bugbear==23.9.16"]
+        args: ["--max-line-length=88"]
   - repo: https://github.com/pycqa/bandit
     rev: 1.7.5
     hooks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,86 @@
+[build-system]
+requires = [
+  "setuptools>=68",
+  "setuptools_scm[toml]>=8.0",
+]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "scicat_ingestor"
+description = "Scicat Ingestor."
+authors = [{ name = "SciCatProject, Scipp Contributor" }]
+license = { file = "LICENSE" }
+readme = "README.md"
+classifiers = [
+    "Intended Audience :: Science/Research",
+    "License :: OSI Approved :: BSD License",
+    "Natural Language :: English",
+    "Operating System :: OS Independent",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3 :: Only",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Topic :: Scientific/Engineering",
+    "Typing :: Typed",
+]
+requires-python = ">=3.10"
+
+# IMPORTANT:
+# Run 'tox -e deps' after making changes here. This will update requirement files.
+# Make sure to list one dependency per line.
+dependencies = [
+  "rich"
+]
+
+dynamic = ["version"]
+
+[project.scripts]
+beamlime = "beamlime.__main__:main"
+
+[project.urls]
+"Bug Tracker" = "https://github.com/SciCatProject/scicat-filewriter-ingest/issues"
+"Documentation" = "https://github.com/SciCatProject/scicat-filewriter-ingest"
+"Source" = "https://github.com/SciCatProject/scicat-filewriter-ingest"
+
+[tool.setuptools_scm]
+
+[tool.pytest.ini_options]
+minversion = "7.0"
+addopts = """
+--strict-config
+--strict-markers
+--import-mode=importlib
+-ra
+-v
+"""
+testpaths = "tests"
+filterwarnings = [
+  "error",
+  'ignore:\n.*Sentinel is not a public part of the traitlets API.*:DeprecationWarning',
+]
+pythonpath = "tests/helpers"
+asyncio_mode = "auto"
+
+[tool.bandit]
+# Excluding tests because bandit doesn't like `assert`.
+exclude_dirs = ["docs/conf.py", "tests"]
+
+[tool.black]
+skip-string-normalization = true
+
+[tool.isort]
+skip_gitignore = true
+profile = "black"
+known_first_party = ["scicat_ingestor"]
+
+[tool.mypy]
+strict = true
+ignore_missing_imports = true
+enable_error_code = [
+    "ignore-without-code",
+    "redundant-expr",
+    "truthy-bool",
+]
+show_error_codes = true
+warn_unreachable = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,13 +30,11 @@ requires-python = ">=3.10"
 # Run 'tox -e deps' after making changes here. This will update requirement files.
 # Make sure to list one dependency per line.
 dependencies = [
-  "rich"
+  "pyscicat",
+  "confluent_kafka",
 ]
 
 dynamic = ["version"]
-
-[project.scripts]
-beamlime = "beamlime.__main__:main"
 
 [project.urls]
 "Bug Tracker" = "https://github.com/SciCatProject/scicat-filewriter-ingest/issues"


### PR DESCRIPTION
## List of the added dev tool and environments:
- src directory: For easier organization of modules
- pyproject.toml: For easier configuration of dev/test tools
- pre-commit hook: For formatting

## Later...
We're currently making the https://github.com/scipp/copier_template general, less scipp-specific. 
Once we have a general copier template, maybe we can apply them here and discard unnecessary things (like deployment or documentation build setup)