### PR TITLE
Metadata computing methods loader

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,11 @@ dynamic = ["version"]
 [project.scripts]
 scicat_ingestor = "scicat_ingestor:main"
 
+[project.entry-points."scicat_ingestor.metadata_extractor"]
+max = "numpy:max"
+min = "numpy:min"
+mean = "numpy:mean"
+
 [tool.setuptools_scm]
 
 [tool.pytest.ini_options]

--- a/src/scicat_metadata.py
+++ b/src/scicat_metadata.py
@@ -1,0 +1,12 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2024 ScicatProject contributors (https://github.com/ScicatProject)
+from importlib.metadata import entry_points
+from typing import Callable
+
+
+def load_metadata_extractors(extractor_name: str) -> Callable:
+    """Load metadata extractors from the entry points."""
+
+    return entry_points(group="scicat_ingestor.metadata_extractor")[
+        extractor_name
+    ].load()

--- a/tests/test_metadata_extractor.py
+++ b/tests/test_metadata_extractor.py
@@ -1,0 +1,12 @@
+import pytest
+
+from scicat_metadata import load_metadata_extractors
+
+
+@pytest.mark.parametrize(
+    ["extractor_name", "expected_result"], [("max", 5), ("min", 1), ("mean", 3)]
+)
+def test_metadata_extractor(extractor_name: str, expected_result: int):
+    """Test if the metadata extractor can be loaded."""
+    test_data = [1, 2, 3, 4, 5]
+    assert load_metadata_extractors(extractor_name)(test_data) == expected_result


### PR DESCRIPTION
@nitrosx  this is the example of how to use `entry-points`...!
And then we can use the entry points name from `pyproject.toml` in the configuration file.