### PR TITLE
Refactoring background ingestor.

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,10 @@ pip install -e .  # It will allow you to use entry-points of the scripts,
 All scripts parse the system arguments and configuration in the same way.
 
 ### Online ingestor (Highest level interface)
+You can start the ingestor daemon with certain configurations.
+
+It will continuously process `wrdn` messages and ingest the nexus files.
+
 ```bash
 scicat_ingestor --verbose -c PATH_TO_CONFIGURATION_FILE.yaml
 ```

--- a/README.md
+++ b/README.md
@@ -2,9 +2,40 @@
 
 # Scicat Filewriter Ingest
 
-## About
-
 A daemon that creates a raw dataset using scicat interface whenever a new file is written by a file-writer.
+
+## How to INSTALL
+```bash
+git clone https://github.com/SciCatProject/scicat-filewriter-ingest.git
+cd scicat-filewriter-ingest
+pip install -e .  # It will allow you to use entry-points of the scripts,
+                  # defined in ``pyproject.toml``, under ``[project.scripts]`` section.
+```
+
+## How to RUN
+
+All scripts parse the system arguments and configuration in the same way.
+
+### Online ingestor (Highest level interface)
+```bash
+scicat_ingestor --verbose -c PATH_TO_CONFIGURATION_FILE.yaml
+```
+
+See [configuration](#configuration) for how to use configuration files.
+
+### Background ingestor  (Lower level interface)
+You can also run the ingestor file by file.
+
+You need to know the path to the nexus file you want to ingest
+and also the path to the ``done_writing_message_file`` as a json file.
+
+```bash
+background_ingestor \\
+    --verbose \\
+    -c PATH_TO_CONFIGURATION_FILE.yaml \\
+    --nexus-file PATH_TO_THE_NEXUS_FILE.nxs \\
+    --done-writing-message-file PATH_TO_THE_MESSAGE_FILE.json
+```
 
 ## Configuration
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,7 @@ dynamic = ["version"]
 
 [project.scripts]
 scicat_ingestor = "scicat_ingestor:main"
+background_ingestor = "background_ingestor:main"
 
 [project.entry-points."scicat_ingestor.metadata_extractor"]
 max = "numpy:max"

--- a/src/background_ingestor.py
+++ b/src/background_ingestor.py
@@ -6,7 +6,7 @@ import pathlib
 
 from scicat_configuration import (
     build_background_ingestor_arg_parser,
-    build_scicat_config,
+    build_scicat_background_ingester_config,
 )
 from scicat_logging import build_logger
 from system_helpers import exit_at_exceptions
@@ -16,7 +16,7 @@ def main() -> None:
     """Main entry point of the app."""
     arg_parser = build_background_ingestor_arg_parser()
     arg_namespace = arg_parser.parse_args()
-    config = build_scicat_config(arg_namespace)
+    config = build_scicat_background_ingester_config(arg_namespace)
     logger = build_logger(config)
 
     # Log the configuration as dictionary so that it is easier to read from the logs
@@ -25,13 +25,13 @@ def main() -> None:
     )
     logger.info(config.to_dict())
 
-    with exit_at_exceptions(logger):
-        nexus_file = pathlib.Path(arg_namespace.nexus_file)
+    with exit_at_exceptions(logger, daemon=False):
+        nexus_file = pathlib.Path(config.single_run_options.nexus_file)
         logger.info("Nexus file to be ingested : ")
         logger.info(nexus_file)
 
         done_writing_message_file = pathlib.Path(
-            arg_namespace.arg_namespace.done_writing_message_file
+            config.single_run_options.done_writing_message_file
         )
         logger.info("Done writing message file linked to nexus file : ")
         logger.info(done_writing_message_file)

--- a/src/background_ingestor.py
+++ b/src/background_ingestor.py
@@ -1,42 +1,15 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2024 ScicatProject contributors (https://github.com/ScicatProject)
+# import scippnexus as snx
 import json
-import logging
 import pathlib
-from collections.abc import Generator
-from contextlib import contextmanager
 
 from scicat_configuration import (
     build_background_ingestor_arg_parser,
     build_scicat_config,
 )
 from scicat_logging import build_logger
-
-# import scippnexus as snx
-
-
-def quit(logger: logging.Logger, unexpected: bool = True) -> None:
-    """Log the message and exit the program."""
-    import sys
-
-    logger.info("Exiting ingestor")
-    sys.exit(1 if unexpected else 0)
-
-
-@contextmanager
-def exit_at_exceptions(logger: logging.Logger) -> Generator[None, None, None]:
-    """Exit the program if an exception is raised."""
-    try:
-        yield
-    except KeyboardInterrupt:
-        logger.info("Received keyboard interrupt.")
-        quit(logger, unexpected=False)
-    except Exception as e:
-        logger.error("An exception occurred: %s", e)
-        quit(logger, unexpected=True)
-    else:
-        logger.error("Loop finished unexpectedly.")
-        quit(logger, unexpected=True)
+from system_helpers import exit_at_exceptions
 
 
 def main() -> None:
@@ -53,7 +26,7 @@ def main() -> None:
     logger.info(config.to_dict())
 
     with exit_at_exceptions(logger):
-        nexus_file = arg_namespace.nexus_file
+        nexus_file = pathlib.Path(arg_namespace.nexus_file)
         logger.info("Nexus file to be ingested : ")
         logger.info(nexus_file)
 

--- a/src/scicat_ingestor.py
+++ b/src/scicat_ingestor.py
@@ -11,7 +11,7 @@ except importlib.metadata.PackageNotFoundError:
 
 del importlib
 
-from scicat_configuration import build_main_arg_parser, build_scicat_config
+from scicat_configuration import build_main_arg_parser, build_scicat_ingester_config
 from scicat_kafka import build_consumer, wrdn_messages
 from scicat_logging import build_logger
 from system_helpers import exit_at_exceptions
@@ -21,7 +21,7 @@ def main() -> None:
     """Main entry point of the app."""
     arg_parser = build_main_arg_parser()
     arg_namespace = arg_parser.parse_args()
-    config = build_scicat_config(arg_namespace)
+    config = build_scicat_ingester_config(arg_namespace)
     logger = build_logger(config)
 
     # Log the configuration as dictionary so that it is easier to read from the logs

--- a/src/scicat_ingestor.py
+++ b/src/scicat_ingestor.py
@@ -11,37 +11,10 @@ except importlib.metadata.PackageNotFoundError:
 
 del importlib
 
-import logging
-from collections.abc import Generator
-from contextlib import contextmanager
-
 from scicat_configuration import build_main_arg_parser, build_scicat_config
 from scicat_kafka import build_consumer, wrdn_messages
 from scicat_logging import build_logger
-
-
-def quit(logger: logging.Logger, unexpected: bool = True) -> None:
-    """Log the message and exit the program."""
-    import sys
-
-    logger.info("Exiting ingestor")
-    sys.exit(1 if unexpected else 0)
-
-
-@contextmanager
-def exit_at_exceptions(logger: logging.Logger) -> Generator[None, None, None]:
-    """Exit the program if an exception is raised."""
-    try:
-        yield
-    except KeyboardInterrupt:
-        logger.info("Received keyboard interrupt.")
-        quit(logger, unexpected=False)
-    except Exception as e:
-        logger.error("An exception occurred: %s", e)
-        quit(logger, unexpected=True)
-    else:
-        logger.error("Loop finished unexpectedly.")
-        quit(logger, unexpected=True)
+from system_helpers import exit_at_exceptions
 
 
 def main() -> None:

--- a/src/scicat_logging.py
+++ b/src/scicat_logging.py
@@ -5,10 +5,10 @@ import logging
 import logging.handlers
 
 import graypy
-from scicat_configuration import ScicatConfig
+from scicat_configuration import IngesterConfig
 
 
-def build_logger(config: ScicatConfig) -> logging.Logger:
+def build_logger(config: IngesterConfig) -> logging.Logger:
     """Build a logger and configure it according to the ``config``."""
     run_options = config.run_options
 

--- a/src/system_helpers.py
+++ b/src/system_helpers.py
@@ -1,0 +1,27 @@
+import logging
+from collections.abc import Generator
+from contextlib import contextmanager
+
+
+def quit(logger: logging.Logger, unexpected: bool = True) -> None:
+    """Log the message and exit the program."""
+    import sys
+
+    logger.info("Exiting ingestor")
+    sys.exit(1 if unexpected else 0)
+
+
+@contextmanager
+def exit_at_exceptions(logger: logging.Logger) -> Generator[None, None, None]:
+    """Exit the program if an exception is raised."""
+    try:
+        yield
+    except KeyboardInterrupt:
+        logger.info("Received keyboard interrupt.")
+        quit(logger, unexpected=False)
+    except Exception as e:
+        logger.error("An exception occurred: %s", e)
+        quit(logger, unexpected=True)
+    else:
+        logger.error("Loop finished unexpectedly.")
+        quit(logger, unexpected=True)

--- a/src/system_helpers.py
+++ b/src/system_helpers.py
@@ -12,7 +12,9 @@ def quit(logger: logging.Logger, unexpected: bool = True) -> None:
 
 
 @contextmanager
-def exit_at_exceptions(logger: logging.Logger) -> Generator[None, None, None]:
+def exit_at_exceptions(
+    logger: logging.Logger, daemon: bool = True
+) -> Generator[None, None, None]:
     """Exit the program if an exception is raised."""
     try:
         yield
@@ -23,5 +25,9 @@ def exit_at_exceptions(logger: logging.Logger) -> Generator[None, None, None]:
         logger.error("An exception occurred: %s", e)
         quit(logger, unexpected=True)
     else:
-        logger.error("Loop finished unexpectedly.")
-        quit(logger, unexpected=True)
+        if daemon:
+            logger.error("Loop finished unexpectedly.")
+            quit(logger, unexpected=True)
+        else:
+            logger.info("Finished successfully.")
+            quit(logger, unexpected=False)

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -1,12 +1,17 @@
 import pathlib
 
 import pytest
-from scicat_configuration import GraylogOptions, RunOptions, ScicatConfig, kafkaOptions
+from scicat_configuration import (
+    GraylogOptions,
+    IngesterConfig,
+    RunOptions,
+    kafkaOptions,
+)
 
 
 @pytest.fixture()
-def scicat_config(tmp_path: pathlib.Path) -> ScicatConfig:
-    return ScicatConfig(
+def scicat_config(tmp_path: pathlib.Path) -> IngesterConfig:
+    return IngesterConfig(
         original_dict={},
         run_options=RunOptions(
             config_file='test',
@@ -26,7 +31,7 @@ def scicat_config(tmp_path: pathlib.Path) -> ScicatConfig:
     )
 
 
-def test_scicat_logging_build_logger(scicat_config: ScicatConfig) -> None:
+def test_scicat_logging_build_logger(scicat_config: IngesterConfig) -> None:
     from scicat_logging import build_logger
 
     logger = build_logger(scicat_config)


### PR DESCRIPTION
- Renamed the background ingestor script so that it can be used as a `module` as well.
- Extracted the system helper function (exiting at exceptions) to a separate helper module
   - The scripts can be more concentrating on the logic.
   - Avoid duplicating code
- Add how to install/run in the readme both, online/background ingestor.


Next step will be adding functionalities into the background ingestor and add tests.