### PR TITLE
Suppress argparser default value setter.

### DIFF
--- a/src/scicat_configuration.py
+++ b/src/scicat_configuration.py
@@ -41,7 +41,6 @@ def _parse_nested_input_args(input_args: argparse.Namespace) -> dict:
     nested_args = {}
     for key, value in vars(input_args).items():
         _insert_item(nested_args, key, value)
-
     return nested_args
 
 
@@ -69,7 +68,7 @@ def build_arg_parser(
 
     **Note**: It can't parse the annotations from parent class.
     """
-    parser = argparse.ArgumentParser()
+    parser = argparse.ArgumentParser(argument_default=argparse.SUPPRESS)
 
     def _add_arguments(dataclass_tp: type, prefixes: tuple[str, ...] = ()) -> None:
         # Add argument group if prefixes are provided


### PR DESCRIPTION
Fixes #77 

@nitrosx  Sorry for the bug...!

It was not ignored, it was just magically given by the argparser by default.

Now it should work as expected.

I also realized that I didn't put the configuration unit tests back after re-implementing the configuration module.

I'll add more tests as well.