### PR TITLE
Allow only one type for a parameter and simplify the code.

### DIFF
--- a/resources/config.sample.json
+++ b/resources/config.sample.json
@@ -14,7 +14,9 @@
   },
   "ingestion": {
     "dry_run": false,
-    "offline_ingestor_executable": "background_ingestor",
+    "offline_ingestor_executable": [
+      "background_ingestor"
+    ],
     "schemas_directory": "schemas",
     "check_if_dataset_exists_by_pid": true,
     "check_if_dataset_exists_by_metadata": true,

--- a/src/scicat_configuration.py
+++ b/src/scicat_configuration.py
@@ -222,10 +222,16 @@ class FileHandlingOptions:
     file_path_type: str = "relative"  # allowed values: absolute and relative
 
 
+def default_offline_ingestor_executable() -> list[str]:
+    return ["background_ingestor"]
+
+
 @dataclass(kw_only=True)
 class IngestionOptions:
     dry_run: bool = False
-    offline_ingestor_executable: str | list[str]= "background_ingestor"
+    offline_ingestor_executable: list[str] = field(
+        default_factory=default_offline_ingestor_executable
+    )
     schemas_directory: str = "schemas"
     check_if_dataset_exists_by_pid: bool = True
     check_if_dataset_exists_by_metadata: bool = True

--- a/src/scicat_online_ingestor.py
+++ b/src/scicat_online_ingestor.py
@@ -37,11 +37,11 @@ from system_helpers import handle_daemon_loop_exceptions
 
 
 def dump_message_to_file_if_needed(
-        *,
-        logger: logging.Logger,
-        message_file_path: pathlib.Path,
-        file_handling_options: FileHandlingOptions,
-        message: WritingFinished,
+    *,
+    logger: logging.Logger,
+    message_file_path: pathlib.Path,
+    file_handling_options: FileHandlingOptions,
+    message: WritingFinished,
 ) -> None:
     """Dump the message to a file according to the configuration."""
     if not file_handling_options.message_to_file:
@@ -93,10 +93,6 @@ def build_online_config(logger: logging.Logger | None = None) -> OnlineIngestorC
     )
 
 
-def _pre_executable_offline_ingestor(offline_ingestor: str | list[str]) -> list[str]:
-    return [offline_ingestor] if isinstance(offline_ingestor, str) else offline_ingestor
-
-
 def main() -> None:
     """Main entry point of the app."""
     tmp_config = build_online_config()
@@ -107,7 +103,7 @@ def main() -> None:
     logger.info('Starting the Scicat online Ingestor with the following configuration:')
     logger.info(config.to_dict())
 
-    with ((handle_daemon_loop_exceptions(logger=logger))):
+    with handle_daemon_loop_exceptions(logger=logger):
         # Kafka consumer
         if (consumer := build_consumer(config.kafka, logger)) is None:
             raise RuntimeError("Failed to build the Kafka consumer")
@@ -139,7 +135,8 @@ def main() -> None:
                     --done-writing-message-file message_file_path
                     # optional depending on the message_saving_options.message_output
                 """
-                cmd = _pre_executable_offline_ingestor(config.ingestion.offline_ingestor_executable) + [
+                cmd = [
+                    *config.ingestion.offline_ingestor_executable,
                     "-c",
                     config.config_file,
                     "--nexus-file",


### PR DESCRIPTION
@nitrosx 
We once tried allowing different types for arguments and it required quite a lot of handling and was easy to make bugs. 
It'd be best to allow only one type.
I think making the commands as a list is completely fine.
Please review&merge this PR first and then #99 is good to go : D

