### PR TITLE
feat(scicat-metadata): multiple schemas support

### DIFF
--- a/resources/d17.imsc.json.example
+++ b/resources/d17.imsc.json.example
@@ -2,7 +2,7 @@
   "id": "d17-example-schema",
   "name": "D17 Instrument Example Schema",
   "order": 1,
-  "import": ["modules/ill.imsc.json.example"],
+  "import": ["ill-module-001"],
   "instrument": "D17",
   "selector": "filename:starts_with:/data/d17",
   "variables": {

--- a/resources/d17.imsc.json.example
+++ b/resources/d17.imsc.json.example
@@ -1,0 +1,56 @@
+{
+  "id": "d17-example-schema",
+  "name": "D17 Instrument Example Schema",
+  "order": 1,
+  "import": ["modules/ill.imsc.json.example"],
+  "instrument": "D17",
+  "selector": "filename:starts_with:/data/d17",
+  "variables": {
+    "instrument_det": {
+      "source": "NXS",
+      "path": "/entry0/instrument/det/value",
+      "value_type": "string"
+    },
+    "incident_angle": {
+      "source": "NXS",
+      "path": "/entry0/instrument/MainParameters/Incident_angle",
+      "value_type": "string"
+    },
+    "opening": {
+      "source": "NXS",
+      "path": "/entry0/instrument/VirtualChopper/actual_opening",
+      "value_type": "string"
+    }
+  },
+  "schema": {
+    "instrument_properties": {
+      "type": "dict",
+      "field_type": "scientific_metadata",
+      "machine_name": "instrumentProperties",
+      "human_name": "D17 Instrument Properties",
+      "value": {
+        "det": {
+          "field_type": "scientific_metadata",
+          "machine_name": "instrument_det",
+          "human_name": "Detector",
+          "value": "<instrument_det>",
+          "type": "string"
+        },
+        "incident_angle": {
+          "field_type": "scientific_metadata",
+          "machine_name": "incident_angle",
+          "human_name": "Incident Angle",
+          "value": "<incident_angle>",
+          "type": "string"
+        },
+        "opening": {
+          "field_type": "scientific_metadata",
+          "machine_name": "opening",
+          "human_name": "Opening",
+          "value": "<opening>",
+          "type": "string"
+        }
+      }
+    }
+  }
+}

--- a/resources/modules/ill.imsc.json.example
+++ b/resources/modules/ill.imsc.json.example
@@ -1,0 +1,131 @@
+{
+  "id": "ill-module-001",
+  "name": "ILL Common Metadata Module",
+  "variables": {
+    "pid": {
+      "source": "NXS",
+      "path": "/entry0/user/proposal",
+      "value_type": "string"
+    },
+    "proposal_id": {
+      "source": "NXS",
+      "path": "/entry0/user/proposal",
+      "value_type": "string"
+    },
+    "dataset_name": {
+      "source": "NXS",
+      "path": "/entry0/title",
+      "value_type": "string"
+    },
+    "instrument_name": {
+      "source": "NXS",
+      "path": "/entry0/instrument/name",
+      "value_type": "string"
+    },
+    "start_time": {
+      "source": "NXS",
+      "path": "/entry0/start_time",
+      "value_type": "date"
+    },
+    "end_time": {
+      "source": "NXS",
+      "path": "/entry0/end_time",
+      "value_type": "date"
+    },
+    "owner": {
+      "source": "NXS",
+      "path": "/entry0/user/name",
+      "value_type": "string"
+    },
+    "owner_email": {
+      "source": "VALUE",
+      "value": "nomad@ill.fr",
+      "value_type": "string"
+    },
+    "creation_location": {
+      "source": "VALUE",
+      "value": "ILL",
+      "value_type": "string"
+    },
+    "owner_group": {
+      "source": "VALUE",
+      "value": "admin",
+      "value_type": "string"
+    },
+    "access_groups": {
+      "source": "VALUE",
+      "value": ["SCIENTIFIC_SUPPORT"],
+      "value_type": "string[]"
+    }
+  },
+  "schema": {
+    "pid": {
+      "field_type": "high_level",
+      "machine_name": "pid",
+      "value": "<pid>",
+      "type": "string"
+    },
+    "type": {
+      "field_type": "high_level",
+      "machine_name": "type",
+      "value": "raw",
+      "type": "string"
+    },
+    "proposal_id": {
+      "field_type": "high_level",
+      "machine_name": "proposalId",
+      "value": "<proposal_id>",
+      "type": "string"
+    },
+    "dataset_name": {
+      "field_type": "high_level",
+      "machine_name": "datasetName",
+      "value": "<dataset_name>",
+      "type": "string"
+    },
+    "owner": {
+      "field_type": "high_level",
+      "machine_name": "owner",
+      "value": "<owner>",
+      "type": "string"
+    },
+    "owner_email": {
+      "field_type": "high_level",
+      "machine_name": "ownerEmail",
+      "value": "<owner_email>",
+      "type": "string"
+    },
+    "creation_location": {
+      "field_type": "high_level",
+      "machine_name": "creationLocation",
+      "value": "<creation_location>",
+      "type": "string"
+    },
+    "start_time": {
+      "field_type": "scientific_metadata",
+      "machine_name": "start_time",
+      "human_name": "Start Time",
+      "value": "<start_time>",
+      "type": "date"
+    },
+    "end_time": {
+      "field_type": "scientific_metadata",
+      "machine_name": "end_time",
+      "human_name": "End Time",
+      "value": "<end_time>",
+      "type": "date"
+    },
+    "owner_group": {
+      "field_type": "high_level",
+      "machine_name": "ownerGroup",
+      "value": "<owner_group>",
+      "type": "string"
+    },
+    "access_groups": {
+      "field_type": "high_level",
+      "machine_name": "accessGroups",
+      "value": "<access_groups>",
+      "type": "string[]"
+    }
+  }
+}

--- a/src/scicat_metadata.py
+++ b/src/scicat_metadata.py
@@ -45,17 +45,19 @@ def _resolve_schema_imports(
     schema: dict[str, Any],
     schema_file_name: pathlib.Path,
     caller_schemas: list[pathlib.Path] | None = None,
+    all_schemas: dict[str, tuple[dict[str, Any], pathlib.Path]] | None = None,
 ) -> dict[str, Any]:
     """
     Resolve imports in the schema dictionary.
 
-    Imports are defined as a list of modules file relative paths to the schema file.
+    Imports are defined as a list of schema IDs to import.
     The importer has priority over imported schemas in case of conflicts.
 
     Args:
         schema: The schema dictionary to resolve imports for
         schema_file_name: Path to the current schema file
         caller_schemas: List of schema file paths in the import chain to detect circular dependencies
+        all_schemas: Dictionary of all available schemas by ID, with (schema_data, file_path) tuples
     """
     if caller_schemas is None:
         caller_schemas = []
@@ -68,21 +70,26 @@ def _resolve_schema_imports(
 
     if "import" in schema:
         if not isinstance(schema["import"], list):
-            raise ValueError("Import must be a list of file paths.")
-        result_schema = schema.copy()
+            raise ValueError("Import must be a list of schema IDs.")
 
+        if all_schemas is None:
+            all_schemas = _load_all_schemas_from_directory(schema_file_name.parent)
+
+        result_schema = schema.copy()
         current_caller_schemas = [*caller_schemas, schema_file_name]
 
-        for import_path in schema["import"]:
-            import_file_path = schema_file_name.parent / pathlib.Path(import_path)
-            if not import_file_path.exists():
-                raise FileNotFoundError(
-                    f"Import file {import_file_path} does not exist."
+        for import_id in schema["import"]:
+            if import_id not in all_schemas:
+                raise ValueError(
+                    f"Import schema ID '{import_id}' not found in available schemas."
                 )
 
-            imported_schema = _load_json_schema(import_file_path)
+            imported_schema, imported_file_path = all_schemas[import_id]
             resolved_imported_schema = _resolve_schema_imports(
-                imported_schema, import_file_path, current_caller_schemas
+                imported_schema,
+                imported_file_path,
+                current_caller_schemas,
+                all_schemas,
             )
 
             for key, value in resolved_imported_schema.items():
@@ -103,6 +110,36 @@ def _resolve_schema_imports(
         return result_schema
 
     return schema
+
+
+def _load_all_schemas_from_directory(
+    base_dir: pathlib.Path,
+) -> dict[str, tuple[dict[str, Any], pathlib.Path]]:
+    """Load all schemas from a directory and its subdirectories, indexed by ID.
+
+    Returns a dictionary where keys are schema IDs and values are tuples of (schema_data, file_path).
+    """
+    schemas = {}
+
+    def _scan_directory(directory: pathlib.Path) -> None:
+        if not directory.exists():
+            return
+
+        for item in directory.iterdir():
+            if item.is_dir():
+                _scan_directory(item)
+            elif (
+                item.is_file()
+                and "imsc.json" in item.name
+                and not item.name.startswith(".")
+            ):
+                schema_data = _load_json_schema(item)
+                if "id" in schema_data:
+                    schemas[schema_data["id"]] = (schema_data, item)
+
+    _scan_directory(base_dir)
+
+    return schemas
 
 
 @dataclass(kw_only=True)

--- a/tests/test_scicat_config.py
+++ b/tests/test_scicat_config.py
@@ -101,6 +101,7 @@ def test_config_with_schema_imports_directory(tmp_path: Path) -> None:
     modules_dir.mkdir()
 
     module_schema = {
+        "id": "test-module-001",
         "variables": {
             "common_var": {
                 "source": "VALUE",
@@ -124,7 +125,7 @@ def test_config_with_schema_imports_directory(tmp_path: Path) -> None:
         "order": 1,
         "instrument": "Test",
         "selector": "filename:starts_with:test",
-        "import": ["modules/module.imsc.json"],
+        "import": ["test-module-001"],
         "variables": {
             "instrument_var": {
                 "source": "VALUE",
@@ -167,6 +168,7 @@ def test_config_validation_with_import_enabled_schemas(tmp_path: Path) -> None:
     modules_dir.mkdir()
 
     module_schema = {
+        "id": "test-config-module",
         "variables": {
             "module_var": {
                 "source": "VALUE",
@@ -190,7 +192,7 @@ def test_config_validation_with_import_enabled_schemas(tmp_path: Path) -> None:
         "order": 1,
         "instrument": "Test",
         "selector": "filename:starts_with:test",
-        "import": ["modules/module.imsc.json"],
+        "import": ["test-config-module"],
         "variables": {
             "specific_var": {
                 "source": "VALUE",

--- a/tests/test_scicat_config.py
+++ b/tests/test_scicat_config.py
@@ -11,6 +11,7 @@ from scicat_configuration import (
     _validate_config_file,
     build_dataclass,
 )
+from scicat_metadata import MetadataSchema
 
 
 @dataclass
@@ -88,3 +89,148 @@ def test_arg_types_match_offline_ingestor_config(template_config_file: Path) -> 
     )
     for name, tp in get_type_hints(OfflineIngestorConfig).items():
         assert isinstance(getattr(config_obj, name), tp)
+
+
+def test_config_with_schema_imports_directory(tmp_path: Path) -> None:
+    """Test that config can specify a schemas directory that contains import-enabled schemas."""
+    import json
+
+    schemas_dir = tmp_path / "schemas"
+    modules_dir = schemas_dir / "modules"
+    schemas_dir.mkdir()
+    modules_dir.mkdir()
+
+    module_schema = {
+        "variables": {
+            "common_var": {
+                "source": "VALUE",
+                "value": "common_value",
+                "value_type": "string",
+            }
+        },
+        "schema": {
+            "common_field": {
+                "machine_name": "common_field",
+                "field_type": "scientific_metadata",
+                "value": "<common_var>",
+                "type": "string",
+            }
+        },
+    }
+
+    instrument_schema = {
+        "id": "test-instrument-schema",
+        "name": "Test Instrument Schema",
+        "order": 1,
+        "instrument": "Test",
+        "selector": "filename:starts_with:test",
+        "import": ["modules/base.imsc.json"],
+        "variables": {
+            "instrument_var": {
+                "source": "VALUE",
+                "value": "instrument_value",
+                "value_type": "string",
+            }
+        },
+        "schema": {
+            "instrument_field": {
+                "machine_name": "instrument_field",
+                "field_type": "scientific_metadata",
+                "value": "<instrument_var>",
+                "type": "string",
+            }
+        },
+    }
+
+    base_file = modules_dir / "base.imsc.json"
+    instrument_file = schemas_dir / "instrument.imsc.json"
+
+    base_file.write_text(json.dumps(module_schema))
+    instrument_file.write_text(json.dumps(instrument_schema))
+
+    schema = MetadataSchema.from_file(instrument_file)
+
+    assert schema.id == "test-instrument-schema"
+    assert "common_var" in schema.variables
+    assert "instrument_var" in schema.variables
+    assert "common_field" in schema.schema
+    assert "instrument_field" in schema.schema
+
+
+def test_config_validation_with_import_enabled_schemas(tmp_path: Path) -> None:
+    """Test that schemas with imports can be loaded from a directory specified in config."""
+    import json
+
+    schemas_dir = tmp_path / "schemas"
+    modules_dir = schemas_dir / "modules"
+    schemas_dir.mkdir()
+    modules_dir.mkdir()
+    module_schema = {
+        "variables": {
+            "base_var": {
+                "source": "VALUE",
+                "value": "base_value",
+                "value_type": "string",
+            }
+        },
+        "schema": {
+            "base_field": {
+                "machine_name": "base_field",
+                "field_type": "scientific_metadata",
+                "value": "<base_var>",
+                "type": "string",
+            }
+        },
+    }
+
+    schema_with_import = {
+        "id": "test-schema",
+        "name": "Test Schema",
+        "order": 1,
+        "instrument": "Test",
+        "selector": "filename:starts_with:test",
+        "import": ["modules/base_module.imsc.json"],
+        "variables": {
+            "specific_var": {
+                "source": "VALUE",
+                "value": "specific_value",
+                "value_type": "string",
+            }
+        },
+        "schema": {
+            "specific_field": {
+                "machine_name": "specific_field",
+                "field_type": "scientific_metadata",
+                "value": "<specific_var>",
+                "type": "string",
+            }
+        },
+    }
+
+    base_file = modules_dir / "base_module.imsc.json"
+    schema_file = schemas_dir / "test.imsc.json"
+
+    base_file.write_text(json.dumps(module_schema))
+    schema_file.write_text(json.dumps(schema_with_import))
+
+    from scicat_metadata import collect_schemas
+
+    try:
+        schemas = collect_schemas(schemas_dir)
+        assert len(schemas) == 1
+        assert "test-schema" in schemas
+
+        loaded_schema = schemas["test-schema"]
+        assert loaded_schema.id == "test-schema"
+
+        assert "base_var" in loaded_schema.variables
+        assert "specific_var" in loaded_schema.variables
+
+        assert "base_field" in loaded_schema.schema
+        assert "specific_field" in loaded_schema.schema
+
+        assert loaded_schema.variables["base_var"].value == "base_value"
+        assert loaded_schema.variables["specific_var"].value == "specific_value"
+
+    except Exception as e:
+        pytest.fail(f"Schema loading with imports failed unexpectedly: {e}")

--- a/tests/test_scicat_config.py
+++ b/tests/test_scicat_config.py
@@ -124,7 +124,7 @@ def test_config_with_schema_imports_directory(tmp_path: Path) -> None:
         "order": 1,
         "instrument": "Test",
         "selector": "filename:starts_with:test",
-        "import": ["modules/base.imsc.json"],
+        "import": ["modules/module.imsc.json"],
         "variables": {
             "instrument_var": {
                 "source": "VALUE",
@@ -142,10 +142,10 @@ def test_config_with_schema_imports_directory(tmp_path: Path) -> None:
         },
     }
 
-    base_file = modules_dir / "base.imsc.json"
+    module_file = modules_dir / "module.imsc.json"
     instrument_file = schemas_dir / "instrument.imsc.json"
 
-    base_file.write_text(json.dumps(module_schema))
+    module_file.write_text(json.dumps(module_schema))
     instrument_file.write_text(json.dumps(instrument_schema))
 
     schema = MetadataSchema.from_file(instrument_file)
@@ -165,19 +165,20 @@ def test_config_validation_with_import_enabled_schemas(tmp_path: Path) -> None:
     modules_dir = schemas_dir / "modules"
     schemas_dir.mkdir()
     modules_dir.mkdir()
+
     module_schema = {
         "variables": {
-            "base_var": {
+            "module_var": {
                 "source": "VALUE",
-                "value": "base_value",
+                "value": "module_value",
                 "value_type": "string",
             }
         },
         "schema": {
-            "base_field": {
-                "machine_name": "base_field",
+            "module_field": {
+                "machine_name": "module_field",
                 "field_type": "scientific_metadata",
-                "value": "<base_var>",
+                "value": "<module_var>",
                 "type": "string",
             }
         },
@@ -189,7 +190,7 @@ def test_config_validation_with_import_enabled_schemas(tmp_path: Path) -> None:
         "order": 1,
         "instrument": "Test",
         "selector": "filename:starts_with:test",
-        "import": ["modules/base_module.imsc.json"],
+        "import": ["modules/module.imsc.json"],
         "variables": {
             "specific_var": {
                 "source": "VALUE",
@@ -207,10 +208,10 @@ def test_config_validation_with_import_enabled_schemas(tmp_path: Path) -> None:
         },
     }
 
-    base_file = modules_dir / "base_module.imsc.json"
+    module_file = modules_dir / "module.imsc.json"
     schema_file = schemas_dir / "test.imsc.json"
 
-    base_file.write_text(json.dumps(module_schema))
+    module_file.write_text(json.dumps(module_schema))
     schema_file.write_text(json.dumps(schema_with_import))
 
     from scicat_metadata import collect_schemas
@@ -223,13 +224,13 @@ def test_config_validation_with_import_enabled_schemas(tmp_path: Path) -> None:
         loaded_schema = schemas["test-schema"]
         assert loaded_schema.id == "test-schema"
 
-        assert "base_var" in loaded_schema.variables
+        assert "module_var" in loaded_schema.variables
         assert "specific_var" in loaded_schema.variables
 
-        assert "base_field" in loaded_schema.schema
+        assert "module_field" in loaded_schema.schema
         assert "specific_field" in loaded_schema.schema
 
-        assert loaded_schema.variables["base_var"].value == "base_value"
+        assert loaded_schema.variables["module_var"].value == "module_value"
         assert loaded_schema.variables["specific_var"].value == "specific_value"
 
     except Exception as e:


### PR DESCRIPTION
Re-implementation of PR: https://github.com/SciCatProject/scicat-ingestor/pull/178 following SciCat community suggestions

## Motivation
Following issue: https://github.com/SciCatProject/scicat-ingestor/issues/173

It is a first step for the objective to ingest files of a complex structure in a facility.
This has full backwards compatibility.

## Description

Adds the possibility to import a schema in another schema, opening the possibility to factorize our configs.

Here is the file structure:
```txt
resources/
├── modules/
│   └── ill.imsc.json.example       # Reusable ILL common metadata
├── d17.imsc.json.example         # D17-specific schema importing ILL module
└── panther.imsc.json                  # Could import ILL module + add panther-specific fields
```

In case of conflict, the importer has the priority over the imported.

## Usage example

Module Schema (modules/ill.imsc.json):
```json
{
  "id": "ill-module-001",
  "name": "ILL Common Metadata Module",
  "variables": {
    "pid": {"source": "NXS", "path": "/entry0/user/proposal", "value_type": "string"},
    "owner": {"source": "NXS", "path": "/entry0/user/name", "value_type": "string"}
  },
  "schema": {
    "pid": {"field_type": "high_level", "machine_name": "pid", "value": "<pid>", "type": "string"}
  }
}
```

Importing Schema (d17.imsc.json):
```json
{
  "id": "d17-schema",
  "name": "D17 Instrument Example Schema",
  "import": ["ill-module-001"],
  "instrument": "D17",
  "order": 1,
  "selector": "filename:starts_with:/data/d17",
  "variables": {
    "detector": {"source": "NXS", "path": "/entry0/instrument/det", "value_type": "string"}
  },
  "schema": {
    "instrument_properties": {"field_type": "scientific_metadata", "value": {"det": "<detector>"}}
  }
}
```

The resulting schema will have variables and schema from both the module and the importer.