### PR TITLE
feat: Add 'contains' selector functionality and corresponding tests

### DIFF
--- a/src/scicat_metadata.py
+++ b/src/scicat_metadata.py
@@ -275,8 +275,13 @@ def _select_applicable_schema(
         else:
             raise ValueError(f"Invalid target name {select_target_name}")
 
+        if select_target_value is None:
+            return False
+
         if select_function_name == "starts_with":
             return select_target_value.startswith(select_argument)
+        elif select_function_name == "contains":
+            return select_argument in select_target_value
         else:
             raise ValueError(f"Invalid function name {select_function_name}")
 

--- a/tests/test_scicat_metadata_schema.py
+++ b/tests/test_scicat_metadata_schema.py
@@ -113,6 +113,55 @@ def test_metadata_schema_selection() -> None:
     )
 
 
+def test_metadata_schema_selection_contains() -> None:
+    schemas = OrderedDict(
+        {
+            "schema1": MetadataSchema(
+                order=1,
+                id="schema1",
+                name="Schema 1",
+                instrument="",
+                selector="filename:contains:wrong_part",
+                variables={},
+                schema={},
+            ),
+            "schema2": MetadataSchema(
+                order=2,
+                id="schema2",
+                name="Schema 2",
+                instrument="",
+                selector="filename:contains:right_part",
+                variables={},
+                schema={},
+            ),
+        }
+    )
+    assert (
+        select_applicable_schema(Path("some_right_part_in_name.nxs"), schemas)
+        == schemas["schema2"]
+    )
+
+
+def test_metadata_schema_selection_contains_no_match() -> None:
+    schemas = OrderedDict(
+        {
+            "schema1": MetadataSchema(
+                order=1,
+                id="schema1",
+                name="Schema 1",
+                instrument="",
+                selector="filename:contains:missing_part",
+                variables={},
+                schema={},
+            ),
+        }
+    )
+    with pytest.raises(
+        Exception, match="No applicable metadata schema configuration found!!"
+    ):
+        select_applicable_schema(Path("some_file.nxs"), schemas)
+
+
 def test_metadata_schema_selection_wrong_selector_target_name_raises() -> None:
     with pytest.raises(ValueError, match="Invalid target name"):
         select_applicable_schema(


### PR DESCRIPTION
Add missing contains selector in the _select_applicable_schema function.
Doc: http://www.scicatproject.org/scicat-ingestor/latest/user-guide/metadata-schemas/#selector-example

This functionality also helps us run integration tests in different environments.