### PR TITLE
Avoid failing at dataset instance creation by failing field construction.

### DIFF
--- a/pixi.lock
+++ b/pixi.lock
@@ -115,6 +115,56 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/14/25/b208c5683343959b670dc001595f2f3737e051da617f66c31f7c4fa93abc/rich-14.3.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl
       - pypi: ./
+  lint:
+    channels:
+    - url: https://conda.anaconda.org/conda-forge/
+    indexes:
+    - https://pypi.org/simple
+    options:
+      pypi-prerelease-mode: if-necessary-or-explicit
+    packages:
+      linux-64:
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-hda65f42_9.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.2.25-hbd8a1cb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/icu-78.2-h33c6efd_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.45.1-default_hbd61a6d_101.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.7.4-hecca717_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.5.2-h3435931_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-15.2.0-he0feb66_18.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-15.2.0-he0feb66_18.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/liblzma-5.8.2-hb03c661_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libmpdec-4.0.0-hb03c661_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.51.2-hf4e2dac_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-15.2.0-h934c35e_18.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.41.3-h5347b49_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.1-hb9d3cd8_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.5-h2d0b736_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.6.1-h35e630c_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.14.3-h32b2ec7_101_cp314.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.14-8_cp314.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/readline-8.3-h853b02a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_h366c992_103.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb78ec9c_6.conda
+      - pypi: https://files.pythonhosted.org/packages/9a/3c/c17fb3ca2d9c3acff52e30b309f538586f9f5b9c9cf454f3845fc9af4881/certifi-2026.2.25-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/67/ff/f6b948ca32e4f2a4576aa129d8bed61f2e0543bf9f5f2b7fc3758ed005c9/charset_normalizer-3.4.4-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/c3/2b/0a93b63a46b2ceaac3de92d494e32aab21bec398b40ac89108bbaa6894c3/confluent_kafka-2.13.0-cp314-cp314-manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/10/20/5c13b0f10dcd69daaa1853385cee819c8c204282f3d0d2fffaa91fdb56b5/ess_streaming_data_types-0.27.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/e8/2d/d2a548598be01649e2d46231d151a6c56d10b964d94043a335ae56ea2d92/flatbuffers-25.12.19-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/82/80/d9de7f4747ab54aad84c479d2c3dad9171de5a7f832ce4229bcef1f472ce/graypy-2.1.0-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/33/5d/65c619e195e0b5e54ea5a95c1bb600c8ff8715e0d09676e4cce56d89f492/h5py-3.15.1-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/4a/db/694fd552295ed091e7418d02b6268ee36092d4c93211136c448fe061fe32/kafka_python-2.3.0-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/94/54/e7d793b573f298e1c9013b8c4dade17d481164aa517d1d7148619c2cedbf/markdown_it_py-4.0.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/5d/6c/7f237821c9642fb2a04d2f1e88b4295677144ca93285fd76eff3bcba858d/numpy-2.4.2-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/88/f9/16491d7ed2a919954993e48aa941b200f38040928474c9e85ea9e64222c3/pyyaml-6.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/1e/db/4254e3eabe8020b458f1a747140d32277ec7a271daf1d235b70dc0b4e6e3/requests-2.32.5-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/14/25/b208c5683343959b670dc001595f2f3737e051da617f66c31f7c4fa93abc/rich-14.3.3-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl
+      - pypi: ./
   test:
     channels:
     - url: https://conda.anaconda.org/conda-forge/
@@ -1036,8 +1086,8 @@ packages:
   requires_python: '>=3.8.0'
 - pypi: ./
   name: scicat-ingestor
-  version: 25.8.1.dev12+g21aab78fb.d20260302
-  sha256: 7ecc144012b0b898a5c38b445aae5d7fb96842e89a8c9125a0731cf2eafc7801
+  version: 25.8.1.dev16+gdb63d7b38.d20260303
+  sha256: e3ed1f2b66cef98d11538067c4a718f5566fe56b407d3cff1e9196a8fd0481e1
   requires_dist:
   - confluent-kafka
   - ess-streaming-data-types

--- a/src/scicat_dataset.py
+++ b/src/scicat_dataset.py
@@ -95,6 +95,13 @@ def to_list(value: Any) -> list:
         raise TypeError()
 
 
+def return_none(value: Any) -> None:
+    if value is not None:
+        raise TypeError('`None` type value should be `None`.')
+
+    return None
+
+
 _DtypeConvertingMap = MappingProxyType(
     {
         "string": to_string,
@@ -106,6 +113,7 @@ _DtypeConvertingMap = MappingProxyType(
         "list": to_list,
         "email": to_string,
         "link": to_string,
+        "none": return_none,
         # TODO: Add email converter
     }
 )
@@ -115,7 +123,7 @@ def convert_to_type(input_value: Any, dtype_desc: str) -> Any:
     if (converter := _DtypeConvertingMap.get(dtype_desc)) is None:
         raise ValueError(
             "Invalid dtype description. Must be one of: ",
-            "string, string[], integer, float, date.",
+            ','.join(_DtypeConvertingMap.keys()),
             f"Got: {dtype_desc}",
         )
     return converter(input_value)
@@ -646,10 +654,19 @@ class MetadataItemValueSpec:
         )
 
 
-def _create_scientific_metadata(
+@dataclass
+class _Failure:
+    target_config: MetadataItemConfig
+    error: Exception
+
+
+def _create_highlevel_metadata_dict(
     *,
-    sm_schemas: list[MetadataItemConfig],
+    metadata_schema: dict[str, MetadataItemConfig],
     variable_map: dict[str, MetadataVariableValueSpec],
+    dataset_options: DatasetOptions,
+    failure_container: list[_Failure],
+    logger: logging.Logger,
 ) -> dict:
     """Create scientific metadata from the metadata schema configuration.
 
@@ -661,15 +678,89 @@ def _create_scientific_metadata(
         The scientific metadata schema configuration.
     variable_map:
         The variable map to render the scientific metadata values.
+    failure_container:
+        Append failure report into.
 
     """
-    metadatas = {
-        item_config.machine_name: MetadataItemValueSpec.from_metadata_item_config(
-            item_config, variable_map
+    result = {}
+    hl_field_configs = _filter_by_field_type(
+        metadata_schema.values(), HIGH_LEVEL_METADATA_TYPE
+    )
+    for hl_field in hl_field_configs:
+        try:
+            result[hl_field.machine_name] = _render_variable_as_type(
+                hl_field.value, variable_map, hl_field.type
+            )
+        except Exception as err:
+            failure_container.append(_Failure(hl_field, err))
+
+    # Auto generate or assign ``pid`` if needed
+    # It has to be done before constructing `ScicatDataset` because
+    # ``pid`` is a mandatory argument.
+    if not dataset_options.allow_dataset_pid and ('pid' in result):
+        logger.info(
+            "PID is not allowed in the dataset by configuration. "
+            "Setting it to `None` in the dataset."
         )
-        for item_config in sm_schemas
-    }
-    return {name: asdict(meta) for name, meta in metadatas.items()}
+        result['pid'] = None
+    elif dataset_options.generate_dataset_pid:
+        logger.info("Auto generating PID for the dataset based on the configuration.")
+        result['pid'] = uuid.uuid4().hex
+
+    return result
+
+
+def _create_scientific_metadata(
+    *,
+    metadata_schema: dict[str, MetadataItemConfig],
+    variable_map: dict[str, MetadataVariableValueSpec],
+    failure_container: list[_Failure],
+) -> dict:
+    """Create scientific metadata from the metadata schema configuration.
+
+    Params
+    ------
+    metadata_schema_id:
+        The ID of the metadata schema configuration.
+    sm_schemas:
+        The scientific metadata schema configuration.
+    variable_map:
+        The variable map to render the scientific metadata values.
+    failure_container:
+        Append failure report into.
+
+    """
+    result = {}
+    sm_schemas = _filter_by_field_type(
+        metadata_schema.values(), SCIENTIFIC_METADATA_TYPE
+    )
+    for item_config in sm_schemas:
+        try:
+            name = item_config.machine_name
+            value_spec = MetadataItemValueSpec.from_metadata_item_config(
+                item_config, variable_map
+            )
+            value_dict = asdict(value_spec)
+            result[name] = value_dict
+        except Exception as err:
+            failure_container.append(_Failure(item_config, err))
+
+    return result
+
+
+def _report_failures(*, logger: logging.Logger, failures: list[_Failure]) -> None:
+    if failures:
+        names = '\n  - '.join(
+            f"human_name: {failure.target_config.human_name}\n"
+            f"machine_name: {failure.target_config.machine_name}\n"
+            f"original_message: '{failure.error}'"
+            for failure in failures
+        )
+        logger.warning(
+            "%d metadata fields failed to be constructed and ignored:\n  - %s.",
+            len(failures),
+            names,
+        )
 
 
 def create_scicat_dataset_instance(
@@ -713,35 +804,37 @@ def create_scicat_dataset_instance(
             invalid_types,
         )
 
+    # Container to collect all failures.
+    failure_list: list[_Failure] = []
+
+    # High Level Schema Fields
+    high_level_fields = _create_highlevel_metadata_dict(
+        metadata_schema=metadata_schema,
+        variable_map=variable_map,
+        dataset_options=config,
+        failure_container=failure_list,
+        logger=logger,
+    )
+
+    # Scientific Metadata Schema Fields
+    scientific_metadata = _create_scientific_metadata(
+        metadata_schema=metadata_schema,
+        variable_map=variable_map,
+        failure_container=failure_list,
+    )
+
+    _report_failures(logger=logger, failures=failure_list)
+
     # Create the dataset instance
     scicat_dataset = ScicatDataset(
         size=sum([file.size for file in data_file_list if file.size is not None]),
         numberOfFiles=len(data_file_list),
         isPublished=False,
-        scientificMetadata=_create_scientific_metadata(
-            sm_schemas=_filter_by_field_type(
-                metadata_schema.values(), SCIENTIFIC_METADATA_TYPE
-            ),  # Scientific metadata schemas
-            variable_map=variable_map,
-        ),
-        **{
-            field.machine_name: _render_variable_as_type(
-                field.value, variable_map, field.type
-            )
-            for field in _filter_by_field_type(
-                metadata_schema.values(), HIGH_LEVEL_METADATA_TYPE
-            )
-            # High level schemas
-        },
+        scientificMetadata=scientific_metadata,
+        **high_level_fields,
     )
 
     # Auto generate or assign default values if needed
-    if not config.allow_dataset_pid and scicat_dataset.pid:
-        logger.info("PID is not allowed in the dataset by configuration.")
-        scicat_dataset.pid = None
-    elif config.generate_dataset_pid:
-        logger.info("Auto generating PID for the dataset based on the configuration.")
-        scicat_dataset.pid = uuid.uuid4().hex
     if scicat_dataset.instrumentId is None:
         scicat_dataset.instrumentId = config.default_instrument_id
         logger.info(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,34 @@
+import logging
+import pathlib
 from dataclasses import dataclass
 
 import pytest
+
+from scicat_metadata import MetadataSchema
+
+
+@pytest.fixture(scope="module")
+def example_schema() -> MetadataSchema:
+    from typing import cast
+
+    import yaml
+
+    from scicat_metadata import _validate_file
+
+    # Turn this yaml string into a stream
+    _example_schema = (
+        pathlib.Path(__file__).parent / "resources/example_schema.imsc.yml"
+    )
+    # Check if the example schema is valid first
+    if not _validate_file(_example_schema, logger=logging.getLogger(__name__)):
+        raise ValueError(
+            "Invalid example schema. "
+            "Use ``scicat_validate_metadata_schema`` to validate it first."
+        )
+
+    return MetadataSchema.from_dict(
+        cast(dict, yaml.safe_load(_example_schema.read_text()))
+    )
 
 
 class FakeLogger:
@@ -13,9 +41,13 @@ class FakeLogger:
         self._info_list = []
         self._warning_list = []
         self._error_list = []
+        self.verbose = False
 
     def _log(self, container: list, msg, args: tuple) -> None:
-        container.append(self.MsgArgs(msg, args))
+        new_msg = self.MsgArgs(msg, args)
+        container.append(new_msg)
+        if self.verbose:
+            print(new_msg)  # noqa: T201
 
     def info(self, msg, *args) -> None:
         self._log(self._info_list, msg, args)

--- a/tests/test_scicat_dataset.py
+++ b/tests/test_scicat_dataset.py
@@ -1,8 +1,12 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2024 ScicatProject contributors (https://github.com/ScicatProject)
+import re
+
 import pytest
 
-from scicat_dataset import convert_to_type
+from scicat_configuration import DatasetOptions
+from scicat_dataset import convert_to_type, create_scicat_dataset_instance
+from scicat_metadata import MetadataSchema, MetadataVariableValueSpec
 
 
 def test_dtype_string_converter() -> None:
@@ -42,5 +46,50 @@ def test_dtype_date_converter() -> None:
 
 
 def test_dtype_converter_invalid_dtype_raises() -> None:
-    with pytest.raises(ValueError, match="Invalid dtype description."):
+    with pytest.raises(ValueError, match=re.escape("Invalid dtype description.")):
         convert_to_type("test", "invalid_type")
+
+
+def test_create_scicat_dataset_instance(
+    example_schema: MetadataSchema, fake_logger
+) -> None:
+    variable_map: dict[str, MetadataVariableValueSpec] = {
+        'pid': MetadataVariableValueSpec(value='some-random-pid'),
+        'proposal_id': MetadataVariableValueSpec(value='proposal-id'),
+        'detector_names': MetadataVariableValueSpec(value='ingetsor'),
+        'sample_temperature': MetadataVariableValueSpec(value=300.0, unit='K'),
+    }
+    scicat_dataset = create_scicat_dataset_instance(
+        metadata_schema=example_schema.schema,
+        variable_map=variable_map,
+        data_file_list=[],
+        config=DatasetOptions(),
+        logger=fake_logger,
+    )
+    # Should not fail anything
+    assert not fake_logger._warning_list
+    # Check some of the fields
+    assert scicat_dataset.pid == 'some-random-pid'
+    assert scicat_dataset.ownerEmail == ''  # Empty in the schema file
+    assert scicat_dataset.scientificMetadata['sample_temperature'] == {
+        'human_name': 'Sample Temperature',
+        'value': '300.0',  # Should be converted to string
+        'unit': 'K',
+        'type': 'string',
+    }
+
+
+def test_create_scicat_dataset_instance_failure_okay(
+    example_schema: MetadataSchema, fake_logger
+) -> None:
+    variable_map: dict[str, MetadataVariableValueSpec] = {
+        'pid': MetadataVariableValueSpec(value='pid')
+    }
+    create_scicat_dataset_instance(
+        metadata_schema=example_schema.schema,
+        variable_map=variable_map,
+        data_file_list=[],
+        config=DatasetOptions(),
+        logger=fake_logger,
+    )
+    assert fake_logger._warning_list

--- a/tests/test_scicat_metadata_schema.py
+++ b/tests/test_scicat_metadata_schema.py
@@ -237,29 +237,6 @@ def nexus_file(
 
 
 @pytest.fixture(scope="module")
-def example_schema() -> MetadataSchema:
-    import logging
-    from typing import cast
-
-    import yaml
-
-    from scicat_metadata import _validate_file
-
-    # Turn this yaml string into a stream
-    _example_schema = Path(__file__).parent / "resources/example_schema.imsc.yml"
-    # Check if the example schema is valid first
-    if not _validate_file(_example_schema, logger=logging.getLogger(__name__)):
-        raise ValueError(
-            "Invalid example schema. "
-            "Use ``scicat_validate_metadata_schema`` to validate it first."
-        )
-
-    return MetadataSchema.from_dict(
-        cast(dict, yaml.safe_load(_example_schema.read_text()))
-    )
-
-
-@pytest.fixture(scope="module")
 def offline_config(example_nexus_file_for_schema_test: Path) -> OfflineIngestorConfig:
     config = OfflineIngestorConfig(
         nexus_file=example_nexus_file_for_schema_test.as_posix(),


### PR DESCRIPTION
We should avoid failing because of metadata schema invalidity or variable map invalidity.
We will still get warnings from the failing fields construction.