### PR TITLE
Avoid raising by variable map parsing failures.

### DIFF
--- a/src/scicat_dataset.py
+++ b/src/scicat_dataset.py
@@ -320,49 +320,82 @@ def _build_default_variable_map(
     }
 
 
+@dataclass
+class _VariableMapFailure:
+    name: str
+    recipe: MetadataVariableConfig
+    error: Exception
+
+
+def _report_variable_map_construction_failures(
+    *, logger: logging.Logger, failures: list[_VariableMapFailure]
+) -> None:
+    if failures:
+        descs = '\n  - '.join(
+            f"name: {failure.name}\n"
+            f"recipe: {failure.recipe}\n"
+            f"original_message: '{failure.error}'"
+            for failure in failures
+        )
+        logger.warning(
+            "%d variables failed to be constructed and ignored:\n  - %s.",
+            len(failures),
+            descs,
+        )
+
+
 def extract_variables_values(
+    *,
     variables: dict[str, MetadataVariableConfig],
     h5file: h5py.File,
     config: OfflineIngestorConfig,
     schema_id: str,
+    logger: logging.Logger,
 ) -> dict[str, MetadataVariableValueSpec]:
     variable_map: dict[str, MetadataVariableValueSpec] = _build_default_variable_map(
         nexus_file_path=pathlib.Path(config.nexus_file),
         ingestor_file_dir=config.ingestion.file_handling.ingestor_files_directory,
         schema_id=schema_id,
     )
+    failure_list: list[_VariableMapFailure] = []
     for variable_name, variable_recipe in variables.items():
-        if isinstance(variable_recipe, VariableConfigNexusFile):
-            value = _retrieve_values_from_file(variable_recipe, h5file)
-        elif isinstance(variable_recipe, VariableConfigScicat):
-            url_template = render_variable_value(
-                variable_recipe.url, variable_map
-            ).value
-            if not isinstance(url_template, str):
-                raise ValueError(f"Invalid URL template: {url_template}")
+        try:
+            if isinstance(variable_recipe, VariableConfigNexusFile):
+                value = _retrieve_values_from_file(variable_recipe, h5file)
+            elif isinstance(variable_recipe, VariableConfigScicat):
+                url_template = render_variable_value(
+                    variable_recipe.url, variable_map
+                ).value
+                if not isinstance(url_template, str):
+                    raise ValueError(f"Invalid URL template: {url_template}")
 
-            full_endpoint_url = render_full_url(url_template, config.scicat)
-            _value = retrieve_value_from_scicat(
-                config=config.scicat,
-                scicat_endpoint_url=full_endpoint_url,
-                field_name=variable_recipe.field,
+                full_endpoint_url = render_full_url(url_template, config.scicat)
+                _value = retrieve_value_from_scicat(
+                    config=config.scicat,
+                    scicat_endpoint_url=full_endpoint_url,
+                    field_name=variable_recipe.field,
+                )
+                # Unit is not retrieved from scicat
+                value = MetadataVariableValueSpec(value=_value)
+            elif isinstance(variable_recipe, VariableConfigValue):
+                value = render_variable_value(variable_recipe.value, variable_map)
+                _operator = _get_operator(variable_recipe.operator)
+                value = _operator(value, variable_recipe)
+
+            else:
+                raise Exception("Invalid variable source: ", variable_recipe.source)
+
+            # Convert dtype to match the target value_type.
+            converted_value = convert_to_type(value.value, variable_recipe.value_type)
+            variable_map[variable_name] = MetadataVariableValueSpec(
+                value=converted_value, unit=value.unit
             )
-            # Unit is not retrieved from scicat
-            value = MetadataVariableValueSpec(value=_value)
-        elif isinstance(variable_recipe, VariableConfigValue):
-            value = render_variable_value(variable_recipe.value, variable_map)
-            _operator = _get_operator(variable_recipe.operator)
-            value = _operator(value, variable_recipe)
+        except Exception as err:
+            failure_list.append(
+                _VariableMapFailure(variable_name, variable_recipe, err)
+            )
 
-        else:
-            raise Exception("Invalid variable source: ", variable_recipe.source)
-
-        # Convert dtype to match the target value_type.
-        variable_map[variable_name] = MetadataVariableValueSpec(
-            value=convert_to_type(value.value, variable_recipe.value_type),
-            unit=value.unit,
-        )
-
+    _report_variable_map_construction_failures(logger=logger, failures=failure_list)
     return variable_map
 
 

--- a/src/scicat_offline_ingestor.py
+++ b/src/scicat_offline_ingestor.py
@@ -252,7 +252,11 @@ def main() -> None:
 
             # define variables values
             variable_map = extract_variables_values(
-                metadata_schema.variables, h5file, config, metadata_schema.id
+                variables=metadata_schema.variables,
+                h5file=h5file,
+                config=config,
+                schema_id=metadata_schema.id,
+                logger=logger,
             )
 
         data_file_list = create_data_file_list(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,10 +1,65 @@
 import logging
 import pathlib
+from collections.abc import Generator
 from dataclasses import dataclass
 
+import h5py
 import pytest
 
+from scicat_configuration import OfflineIngestorConfig
 from scicat_metadata import MetadataSchema
+
+
+@pytest.fixture(scope="module")
+def example_nexus_file_for_schema_test(
+    tmp_path_factory: pytest.TempdirFactory,
+) -> pathlib.Path:
+    tmp_path = pathlib.Path(
+        tmp_path_factory.mktemp("example_nexus_file_for_schema_tests")
+    )
+    example_file = tmp_path / "nexus_for_testing.h5"
+    with h5py.File(example_file, "w") as f:
+        entry_gr = f.create_group("/entry")
+        entry_gr.create_dataset("entry_identifier_uuid", data=["supposedly-long-uuid"])
+        entry_gr.create_dataset("experiment_identifier", data=["123456"])
+        instrument_gr = entry_gr.create_group("instrument")
+        instrument_gr.create_dataset("name", data=["Test Instrument"])
+        detectors = instrument_gr.create_group("detectors")
+        det_1 = detectors.create_group('detector_1')
+        det_2 = detectors.create_group('detector_2')
+        det_3 = detectors.create_group('zdet_3')  # Purposely not matching pattern
+        for i, det in enumerate((det_1, det_2, det_3)):
+            det.create_dataset("name", data=[f"Detector Name {i + 1}"])
+
+        sample_gr = entry_gr.create_group("sample")
+        temperature = sample_gr.create_dataset("temperature", data=[300.0])
+        temperature.attrs["units"] = "K"
+
+    return example_file
+
+
+@pytest.fixture(scope="module")
+def nexus_file(
+    example_nexus_file_for_schema_test: pathlib.Path,
+) -> Generator[h5py.File, None, None]:
+    with h5py.File(example_nexus_file_for_schema_test, "r") as f:
+        yield f
+
+
+@pytest.fixture(scope="module")
+def offline_config(
+    example_nexus_file_for_schema_test: pathlib.Path,
+) -> OfflineIngestorConfig:
+    config = OfflineIngestorConfig(
+        nexus_file=example_nexus_file_for_schema_test.as_posix(),
+        done_writing_message_file="",
+        config_file="",
+        id="",
+    )
+    config.ingestion.file_handling.ingestor_files_directory = (
+        example_nexus_file_for_schema_test.parent.as_posix()
+    )
+    return config
 
 
 @pytest.fixture(scope="module")

--- a/tests/test_scicat_dataset.py
+++ b/tests/test_scicat_dataset.py
@@ -2,10 +2,15 @@
 # Copyright (c) 2024 ScicatProject contributors (https://github.com/ScicatProject)
 import re
 
+import h5py
 import pytest
 
-from scicat_configuration import DatasetOptions
-from scicat_dataset import convert_to_type, create_scicat_dataset_instance
+from scicat_configuration import DatasetOptions, OfflineIngestorConfig
+from scicat_dataset import (
+    convert_to_type,
+    create_scicat_dataset_instance,
+    extract_variables_values,
+)
 from scicat_metadata import MetadataSchema, MetadataVariableValueSpec
 
 
@@ -48,6 +53,59 @@ def test_dtype_date_converter() -> None:
 def test_dtype_converter_invalid_dtype_raises() -> None:
     with pytest.raises(ValueError, match=re.escape("Invalid dtype description.")):
         convert_to_type("test", "invalid_type")
+
+
+def test_create_scicat_extract_variables_values(
+    nexus_file: h5py.File,
+    example_schema: MetadataSchema,
+    fake_logger,
+    offline_config: OfflineIngestorConfig,
+) -> None:
+    variable_map = extract_variables_values(
+        variables=example_schema.variables,
+        h5file=nexus_file,
+        config=offline_config,
+        schema_id=example_schema.id,
+        logger=fake_logger,
+    )
+    variable_recipes = example_schema.variables
+    for nexus_str_variable in ('pid', 'proposal_id', 'instrument_name'):
+        assert (
+            variable_map[nexus_str_variable].value
+            == nexus_file[variable_recipes[nexus_str_variable].path][()][0].decode()
+        )
+    assert variable_map['sample_temperature'].value == 300.0
+    assert variable_map['sample_temperature'].unit == 'K'
+    assert variable_map['detector_names_all'].value == [
+        f"Detector Name {i + 1}" for i in range(3)
+    ]
+    assert variable_map['detector_names_list'].value == [
+        f"Detector Name {i + 1}" for i in range(2)
+    ]
+    # Should not fail at all
+    assert not fake_logger._warning_list
+
+
+def test_create_scicat_extract_variables_values_failure_okay(
+    nexus_file: h5py.File,
+    example_schema: MetadataSchema,
+    fake_logger,
+    offline_config: OfflineIngestorConfig,
+) -> None:
+    from copy import deepcopy
+
+    invalid_schema = deepcopy(example_schema)
+    invalid_schema.variables['pid'].path = '/obviously/wrong/path'
+
+    extract_variables_values(
+        variables=invalid_schema.variables,
+        h5file=nexus_file,
+        config=offline_config,
+        schema_id=invalid_schema.id,
+        logger=fake_logger,
+    )
+    # Failures should be ignored
+    assert fake_logger._warning_list
 
 
 def test_create_scicat_dataset_instance(

--- a/tests/test_scicat_metadata_schema.py
+++ b/tests/test_scicat_metadata_schema.py
@@ -1,7 +1,6 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2024 ScicatProject contributors (https://github.com/ScicatProject)
 from collections import OrderedDict
-from collections.abc import Generator
 from pathlib import Path
 
 import h5py
@@ -204,55 +203,8 @@ def test_metadata_schema_selection_wrong_selector_function_name_raises() -> None
         )
 
 
-@pytest.fixture(scope="module")
-def example_nexus_file_for_schema_test(tmp_path_factory: pytest.TempdirFactory) -> Path:
-    tmp_path = Path(tmp_path_factory.mktemp("example_nexus_file_for_schema_tests"))
-    example_file = tmp_path / "nexus_for_testing.h5"
-    with h5py.File(example_file, "w") as f:
-        entry_gr = f.create_group("/entry")
-        entry_gr.create_dataset("entry_identifier_uuid", data=["supposedly-long-uuid"])
-        entry_gr.create_dataset("experiment_identifier", data=["123456"])
-        instrument_gr = entry_gr.create_group("instrument")
-        instrument_gr.create_dataset("name", data=["Test Instrument"])
-        detectors = instrument_gr.create_group("detectors")
-        det_1 = detectors.create_group('detector_1')
-        det_2 = detectors.create_group('detector_2')
-        det_3 = detectors.create_group('zdet_3')  # Purposely not matching pattern
-        for i, det in enumerate((det_1, det_2, det_3)):
-            det.create_dataset("name", data=[f"Detector Name {i + 1}"])
-
-        sample_gr = entry_gr.create_group("sample")
-        temperature = sample_gr.create_dataset("temperature", data=[300.0])
-        temperature.attrs["units"] = "K"
-
-    return example_file
-
-
-@pytest.fixture(scope="module")
-def nexus_file(
-    example_nexus_file_for_schema_test: Path,
-) -> Generator[h5py.File, None, None]:
-    with h5py.File(example_nexus_file_for_schema_test, "r") as f:
-        yield f
-
-
-@pytest.fixture(scope="module")
-def offline_config(example_nexus_file_for_schema_test: Path) -> OfflineIngestorConfig:
-    config = OfflineIngestorConfig(
-        nexus_file=example_nexus_file_for_schema_test.as_posix(),
-        done_writing_message_file="",
-        config_file="",
-        id="",
-    )
-    config.ingestion.file_handling.ingestor_files_directory = (
-        example_nexus_file_for_schema_test.parent.as_posix()
-    )
-    return config
-
-
 def test_metadata_variable_default_variables(
-    nexus_file: h5py.File,
-    offline_config: OfflineIngestorConfig,
+    nexus_file: h5py.File, offline_config: OfflineIngestorConfig, fake_logger
 ) -> None:
     import datetime
     import uuid
@@ -265,6 +217,7 @@ def test_metadata_variable_default_variables(
         h5file=nexus_file,
         schema_id=example_id,
         config=offline_config,
+        logger=fake_logger,
     )
     nexus_file_path = Path(offline_config.nexus_file)
     assert isinstance(variable_values['ingestor_run_id'].value, str)
@@ -287,6 +240,7 @@ def test_metadata_variable_nexus(
     nexus_file: h5py.File,
     example_schema: MetadataSchema,
     offline_config: OfflineIngestorConfig,
+    fake_logger,
 ) -> None:
     from scicat_dataset import extract_variables_values
 
@@ -295,6 +249,7 @@ def test_metadata_variable_nexus(
         h5file=nexus_file,
         schema_id=example_schema.id,
         config=offline_config,
+        logger=fake_logger,
     )
     assert variable_values['pid'] == MetadataVariableValueSpec(
         value='supposedly-long-uuid'
@@ -318,6 +273,7 @@ def test_metadata_variable_raw_values(
     nexus_file: h5py.File,
     example_schema: MetadataSchema,
     offline_config: OfflineIngestorConfig,
+    fake_logger,
 ) -> None:
     from scicat_dataset import extract_variables_values
 
@@ -326,6 +282,7 @@ def test_metadata_variable_raw_values(
         h5file=nexus_file,
         schema_id=example_schema.id,
         config=offline_config,
+        logger=fake_logger,
     )
     assert variable_values['detector_names'] == MetadataVariableValueSpec(
         value="Detector Name 1, Detector Name 2"
@@ -339,6 +296,7 @@ def test_metadata_schema_items(
     nexus_file: h5py.File,
     example_schema: MetadataSchema,
     offline_config: OfflineIngestorConfig,
+    fake_logger,
 ) -> None:
     """This test is techniqually about creating ScicatDataset instance
     but currently we do not build schema items separately before
@@ -356,6 +314,7 @@ def test_metadata_schema_items(
         h5file=nexus_file,
         schema_id=example_schema.id,
         config=offline_config,
+        logger=fake_logger,
     )
     dataset = create_scicat_dataset_instance(
         metadata_schema=example_schema.schema,


### PR DESCRIPTION
Variable parsing has so many places that can go wrong...

The failure in variable map construction might cause failures in the schema field construction because of their dependencies.
But we should avoid raising if possible.


We should add integration tests in the dmsc-nightly or unit tests in the nexus json template and/or schema repo...
Opened an issue: https://git.esss.dk/dmsc-nightly/dmsc-nightly/-/issues/82