### PR TITLE
Update logging messages and separate dev-tools from the metadata module.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,7 @@ scicat_ingestor = "scicat_online_ingestor:main"
 scicat_background_ingestor = "scicat_offline_ingestor:main"
 # Dev Tools
 scicat_validate_ingestor_config = "scicat_configuration:validate_config_file"
-scicat_validate_metadata_schema = "scicat_metadata:validate_schema"
+scicat_validate_metadata_schema = "scicat_devtools:validate_schema"
 scicat_synchronize_config = "scicat_configuration:synchronize_config_file"
 scicat_json_to_yaml = "scicat_configuration:json_to_yaml"
     # We don't have to test this json to yaml script because we always check if

--- a/src/scicat_communication.py
+++ b/src/scicat_communication.py
@@ -66,7 +66,7 @@ def create_scicat_dataset(
     result: dict = response.json()
     if not response.ok:
         logger.error(
-            "Failed to create new dataset. \nData file %s. \nError message from scicat backend: \n%s",
+            "Failed to create new dataset with data file %s. Error message from scicat backend: %s",
             data_file_path,
             result.get("error", {}),
         )
@@ -75,7 +75,7 @@ def create_scicat_dataset(
         )
 
     logger.info(
-        "Dataset created successfully. \nData file: %s. \nDataset pid: %s",
+        "Dataset created successfully with data file: %s, Dataset pid: %s",
         data_file_path,
         result.get("pid"),
     )
@@ -106,7 +106,7 @@ def create_scicat_origdatablock(
     result: dict = response.json()
     if not response.ok:
         logger.error(
-            "Failed to create new origdatablock. \nData file %s. \nError message from scicat backend: \n%s",
+            "Failed to create new origdatablock with data file %s. Error message from scicat backend: %s",
             data_file_path,
             result.get("error", {}),
         )
@@ -115,7 +115,7 @@ def create_scicat_origdatablock(
         )
 
     logger.info(
-        "Origdatablock created successfully. \nData file: %s. \nOrigdatablock pid: %s",
+        "Origdatablock created successfully with data file: %s, Origdatablock pid: %s",
         data_file_path,
         result['_id'],
     )
@@ -144,7 +144,7 @@ def check_dataset_by_pid(
     dataset_exists = response.ok
     # Log the result
     if response.ok:
-        logger.info("Retrieved %s dataset(s) from SciCat", len(response.json()))
+        logger.info("Retrieved %s dataset(s) from SciCat.", len(response.json()))
         logger.info("Dataset with pid %s exists.", pid)
     # Filter 404 error code.
     # Scicat returns 404 error code when the file does not exist.
@@ -153,10 +153,10 @@ def check_dataset_by_pid(
     elif response.status_code == 404:
         logger.info("Dataset with pid %s does not exist.", pid)
     else:
-        logger.error(
-            "Failed to check dataset existence by pid %s\n"
-            "with status code: %s. \n"
-            "Error message from scicat backend: \n%s\n"
+        logger.warning(
+            "Failed to check dataset existence by pid %s "
+            "with status code: %s. "
+            "Error message from scicat backend: %s. "
             "Assuming the dataset does not exist.",
             pid,
             response.status_code,
@@ -187,7 +187,7 @@ def check_dataset_by_metadata(
 
     # Log the response
     if response.ok:
-        logger.info("Retrieved %s dataset(s) from SciCat", len(response.json()))
+        logger.info("Retrieved %s dataset(s) from SciCat.", len(response.json()))
         logger.info("Dataset with metadata %s exists.", metadata_dict)
     # Filter 404 error code.
     # Scicat returns 404 error code when the file does not exist.
@@ -196,10 +196,10 @@ def check_dataset_by_metadata(
     elif response.status_code == 404:
         logger.info("Dataset with metadata %s does not exist.", metadata_dict)
     else:
-        logger.error(
-            "Failed to check dataset existence by metadata key %s \n"
-            "with status code: %s \n"
-            "Error message from scicat backend: \n%s\n"
+        logger.warning(
+            "Failed to check dataset existence by metadata key %s "
+            "with status code: %s. "
+            "Error message from scicat backend: %s. "
             "Assuming the dataset does not exist.",
             metadata_key,
             response.status_code,

--- a/src/scicat_configuration.py
+++ b/src/scicat_configuration.py
@@ -261,6 +261,25 @@ class KafkaOptions:
     auto_offset_reset: str = "earliest"
     """Kafka auto offset reset."""
 
+    def __str__(self):
+        # Normally ``asdict`` is preferred,
+        # But since the kafka option may contain password,
+        # we do not want to accidentally print them, i.e. logging.
+        # Therefore we build the string representation
+        # explicitly without user credentials.
+        dict_option = {
+            'topics': self.topics,
+            'group_id': self.group_id,
+            'bootstrap_servers': self.bootstrap_servers,
+            'security_protocol': self.security_protocol,
+            'sasl_mechanism': self.sasl_mechanism,
+            'ssl_ca_location': self.ssl_ca_location,
+            'individual_message_commit': self.individual_message_commit,
+            'enable_auto_commit': self.enable_auto_commit,
+            'auto_offset_reset': self.auto_offset_reset,
+        }
+        return json.dumps(dict_option)
+
 
 @dataclass(kw_only=True)
 class FileHandlingOptions:
@@ -429,7 +448,7 @@ class OfflineIngestorConfig:
 T = TypeVar("T")
 
 
-def build_dataclass(
+def build_dataclass[T](
     *,
     tp: type[T],
     data: dict,
@@ -441,10 +460,10 @@ def build_dataclass(
     unused_keys = set(data.keys()) - set(type_hints.keys())
     if unused_keys:
         # If ``data`` contains unnecessary fields.
-        unused_keys_repr = "\n\t\t- ".join(
+        unused_keys_repr = ", ".join(
             ".".join((*prefixes, unused_key)) for unused_key in unused_keys
         )
-        error_message = f"Invalid argument found: \n\t\t- {unused_keys_repr}"
+        error_message = f"Invalid argument found: {unused_keys_repr}"
         if logger is not None:
             logger.warning(error_message)
         if strict:
@@ -489,7 +508,7 @@ def merge_config_and_input_args(
     )
 
 
-def _validate_config_file(target_type: type[T], config_file: Path) -> T:
+def _validate_config_file[T](target_type: type[T], config_file: Path) -> T:
     config = {**_load_config(config_file), "config_file": config_file.as_posix()}
     return build_dataclass(tp=target_type, data=config, strict=True)
 

--- a/src/scicat_dataset.py
+++ b/src/scicat_dataset.py
@@ -3,6 +3,7 @@
 import ast
 import copy
 import datetime
+import json
 import logging
 import os.path
 import pathlib
@@ -327,19 +328,22 @@ class _VariableMapFailure:
     recipe: MetadataVariableConfig
     error: Exception
 
+    def __str__(self):
+        failure_dict = {
+            'name': self.name,
+            'recipe': asdict(self.recipe),
+            'error': str(self.error.__class__.__name__) + "('" + str(self.error) + "')",
+        }
+        return json.dumps(failure_dict)
+
 
 def _report_variable_map_construction_failures(
     *, logger: logging.Logger, failures: list[_VariableMapFailure]
 ) -> None:
     if failures:
-        descs = '\n  - '.join(
-            f"name: {failure.name}\n"
-            f"recipe: {failure.recipe}\n"
-            f"original_message: '{failure.error}'"
-            for failure in failures
-        )
+        descs = ', '.join(str(failure) for failure in failures)
         logger.warning(
-            "%d variables failed to be constructed and ignored:\n  - %s.",
+            "%d variables failed to be constructed and ignored: [%s].",
             len(failures),
             descs,
         )
@@ -700,9 +704,17 @@ class MetadataItemValueSpec:
 
 
 @dataclass
-class _Failure:
+class _HighlevelMetadataFailure:
     target_config: MetadataItemConfig
     error: Exception
+
+    def __str__(self) -> str:
+        failure_dict = {
+            'human_name': self.target_config.human_name,
+            'machine_name': self.target_config.machine_name,
+            'error': str(self.error.__class__.__name__) + "('" + str(self.error) + "')",
+        }
+        return json.dumps(failure_dict)
 
 
 def _create_highlevel_metadata_dict(
@@ -710,7 +722,7 @@ def _create_highlevel_metadata_dict(
     metadata_schema: dict[str, MetadataItemConfig],
     variable_map: dict[str, MetadataVariableValueSpec],
     dataset_options: DatasetOptions,
-    failure_container: list[_Failure],
+    failure_container: list[_HighlevelMetadataFailure],
     logger: logging.Logger,
 ) -> dict:
     """Create scientific metadata from the metadata schema configuration.
@@ -737,7 +749,7 @@ def _create_highlevel_metadata_dict(
                 hl_field.value, variable_map, hl_field.type
             )
         except Exception as err:
-            failure_container.append(_Failure(hl_field, err))
+            failure_container.append(_HighlevelMetadataFailure(hl_field, err))
 
     # Auto generate or assign ``pid`` if needed
     # It has to be done before constructing `ScicatDataset` because
@@ -759,7 +771,7 @@ def _create_scientific_metadata(
     *,
     metadata_schema: dict[str, MetadataItemConfig],
     variable_map: dict[str, MetadataVariableValueSpec],
-    failure_container: list[_Failure],
+    failure_container: list[_HighlevelMetadataFailure],
 ) -> dict:
     """Create scientific metadata from the metadata schema configuration.
 
@@ -788,21 +800,18 @@ def _create_scientific_metadata(
             value_dict = asdict(value_spec)
             result[name] = value_dict
         except Exception as err:
-            failure_container.append(_Failure(item_config, err))
+            failure_container.append(_HighlevelMetadataFailure(item_config, err))
 
     return result
 
 
-def _report_failures(*, logger: logging.Logger, failures: list[_Failure]) -> None:
+def _report_highlevel_metadata_build_failures(
+    *, logger: logging.Logger, failures: list[_HighlevelMetadataFailure]
+) -> None:
     if failures:
-        names = '\n  - '.join(
-            f"human_name: {failure.target_config.human_name}\n"
-            f"machine_name: {failure.target_config.machine_name}\n"
-            f"original_message: '{failure.error}'"
-            for failure in failures
-        )
+        names = ', '.join(str(failure) for failure in failures)
         logger.warning(
-            "%d metadata fields failed to be constructed and ignored:\n  - %s.",
+            "%d metadata fields failed to be constructed and ignored: [%s].",
             len(failures),
             names,
         )
@@ -843,14 +852,14 @@ def create_scicat_dataset_instance(
 
     if any(invalid_types):
         logger.warning(
-            "Invalid metadata schema types found: %s .\nValid types are: %s. "
+            "Invalid metadata schema types found: %s. Valid types are: %s. "
             "Metadata items with invalid types will be ignored.",
             VALID_METADATA_TYPES,
             invalid_types,
         )
 
     # Container to collect all failures.
-    failure_list: list[_Failure] = []
+    failure_list: list[_HighlevelMetadataFailure] = []
 
     # High Level Schema Fields
     high_level_fields = _create_highlevel_metadata_dict(
@@ -868,7 +877,7 @@ def create_scicat_dataset_instance(
         failure_container=failure_list,
     )
 
-    _report_failures(logger=logger, failures=failure_list)
+    _report_highlevel_metadata_build_failures(logger=logger, failures=failure_list)
     high_level_fields['size'] = sum(
         [file.size for file in data_file_list if file.size is not None]
     )
@@ -885,7 +894,8 @@ def create_scicat_dataset_instance(
     if missing_mandatory_fields:
         # Since the fallback schema definitions should have all mandatory fields,
         # this condition should never reach.
-        # Therefore despite of the no-raise principal it should raise if this condition is met.
+        # Therefore despite of the no-raising policy,
+        # it should raise if this condition is met.
         err_msg = "Missing mandatory fields for scicat dataset: %s."
         missing_fields_str = ', '.join(missing_mandatory_fields)
         logger.error(err_msg, missing_fields_str)
@@ -900,8 +910,8 @@ def create_scicat_dataset_instance(
     if unexpected_fields:
         # Unexpected fields imply broken metadata schema.
         # scicat-ingestor reports them but do not raise and ignore the unexpected fields.
-        logger.error(
-            "Found unexpected metadata fields for scicat dataset: %s.\n"
+        logger.warning(
+            "Found unexpected metadata fields for scicat dataset: %s. "
             "Unexpected metadata fields will be ignored.",
             ', '.join(unexpected_fields),
         )

--- a/src/scicat_devtools.py
+++ b/src/scicat_devtools.py
@@ -1,0 +1,196 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2026 ScicatProject contributors (https://github.com/ScicatProject)
+import argparse
+import logging
+import pathlib
+
+from scicat_logging import build_devtool_logger
+from scicat_metadata import (
+    VALID_METADATA_TYPES,
+    MetadataItemConfig,
+    MetadataSchema,
+    _is_json_file,
+    list_schema_file_names,
+)
+
+
+def _collect_target_files(
+    schema_file: pathlib.Path, logger: logging.Logger
+) -> list[pathlib.Path]:
+    if not schema_file.exists():
+        raise FileNotFoundError(f"Schema file(location) {schema_file} does not exist.")
+    elif schema_file.is_dir():
+        logger.info("Collecting schema files from the directory `%s`...", schema_file)
+        schema_files = list_schema_file_names(schema_file)
+        if not schema_files:
+            raise FileNotFoundError(
+                f"No schema files found in the directory {schema_file}."
+            )
+        file_list = '\n - '.join([file_path.name for file_path in schema_files])
+        logger.info("Found %d schema files.\n - %s", len(schema_files), file_list)
+    else:
+        schema_files = [schema_file]
+
+    return schema_files
+
+
+def _parse_args() -> argparse.Namespace:
+    arg_parser = argparse.ArgumentParser(
+        description="Validate the metadata schema files."
+    )
+    arg_parser.add_argument(
+        type=str,
+        help="Schema file/directory path (imsc) to validate. If a directory is passed, "
+        "all schema files in the directory will be validated.",
+        dest="schema_file",
+    )
+    return arg_parser.parse_args()
+
+
+def _validate_mandatory_machine_names(
+    schema: MetadataSchema, file_name: str, logger: logging.Logger
+) -> bool:
+    MANDATORY_MACHINE_NAMES = {
+        'datasetName',
+        'principalInvestigator',
+        'creationLocation',
+        'owner',
+        'ownerEmail',
+        'sourceFolder',
+        'contactEmail',
+        'creationTime',
+    }
+    machine_names = {field.machine_name for field in schema.schema.values()}
+    if not MANDATORY_MACHINE_NAMES.issubset(machine_names):
+        missing = MANDATORY_MACHINE_NAMES - machine_names
+        logger.error(
+            "Schema file [red]%s[/red] is missing mandatory fields: [yellow]%s[/yellow]",
+            file_name,
+            '[/yellow], [yellow]'.join(missing),
+        )
+        return False
+
+    logger.info("All mandatory [green]machine names[/green] found.")
+    return True
+
+
+def _validate_schema_selector(selector: str | dict, logger: logging.Logger) -> bool:
+    if isinstance(selector, str):
+        if len(selector.split(":")) != 3:
+            logger.error(
+                "Invalid selector format: '[yellow]%s[/yellow]' "
+                "Selector should be <bold>field:fiter_type:value</bold>",
+                selector,
+            )
+            return False
+    elif isinstance(selector, dict):
+        for conditions in selector.values():
+            return all(_validate_schema_selector(item, logger) for item in conditions)
+
+    logger.info("All [green]schema selector[/green] validated.")
+    return True
+
+
+def _validate_schema_item_config_type(
+    metadata_item_configs: dict[str, MetadataItemConfig], logger: logging.Logger
+) -> bool:
+    invalid_types = [
+        field.field_type
+        for field in metadata_item_configs.values()
+        if field.field_type not in VALID_METADATA_TYPES
+    ]
+
+    if any(invalid_types):
+        logger.error(
+            "Invalid metadata schema types found: %s .\nValid types are: %s. "
+            "Metadata items with invalid types will be ignored.",
+            VALID_METADATA_TYPES,
+            invalid_types,
+        )
+        return False
+
+    return True
+
+
+def _validate_file(schema_file: pathlib.Path, logger: logging.Logger) -> bool:
+    logger.info(
+        "Checking schema file: [bold purple]%s [/bold purple]", schema_file.name
+    )
+    # Check if it is a json file
+    if _is_json_file(schema_file.read_text()):
+        logger.warning(
+            "Schema file [yellow]%s[/yellow] is in "
+            "[bold yellow]JSON[/bold yellow] format. "
+            "It is recommended to use [bold yellow]YAML[/bold yellow] format for new schema files.",
+            schema_file,
+        )
+        return False
+    # Try building the `MetadataSchema` from the file.
+    try:
+        schema = MetadataSchema.from_file(schema_file)
+        msg = "Schema file [green]%s[/ green] has [bold green]VALID[/bold green] structure."
+        logger.info(msg, schema_file.name)
+    except Exception as e:
+        msg = "Schema file [red]%s[/red] is [bold red]INVALID[/bold red]: %s"
+        logger.error(msg, schema_file.name, e)
+        return False
+
+    return (
+        # Validate schema
+        # Manually check mandatory machine names
+        # They are part of fields of `scicat_dataset.ScicatDataset` dataclass.
+        # Some of the mandatory arguments are not filled by schema definition.
+        _validate_mandatory_machine_names(schema, schema_file.name, logger)
+        and _validate_schema_selector(schema.selector, logger)
+        # Validate item type config. It's a free field but should be one of valid types.
+        and _validate_schema_item_config_type(schema.schema, logger)
+    )
+
+
+def validate_schema(
+    *, schema_path: pathlib.Path | None = None, logger: logging.Logger | None = None
+) -> None:
+    """Validate the schema file."""
+    if schema_path is None:
+        # Parse command line arguments
+        args = _parse_args()
+        schema_path = pathlib.Path(args.schema_file)
+
+    if logger is None:
+        # Build a logger
+        logger = build_devtool_logger("validate-schema-file")
+
+    logger.info("Scicat ingestor metadata schema files validation test.")
+    logger.info("It only validates if the schema file has a valid structure.")
+
+    # Collect schema files
+    schema_files = _collect_target_files(schema_path, logger)
+    if not schema_files:
+        raise ValueError("No schema file found to validate.")
+
+    logger.info("Validating %d schema files...", len(schema_files))
+
+    # Collect validities of all files first
+    # to avoid stopping on the first invalid file.
+    validities = {
+        schema_file.name: _validate_file(schema_file, logger)
+        for schema_file in schema_files
+    }
+    if all(validities.values()):
+        logger.info(
+            "All schema files,\n  - %s\nare [bold green]VALID[/bold green].",
+            '\n  - '.join(validities.keys()),
+        )
+    else:
+        invalid_files = {k for k, _ in filter(lambda kv: not kv[1], validities.items())}
+        valid_files = set(validities.keys()) - invalid_files
+        if valid_files:
+            logger.info(
+                "[bold green]Valid[/bold green] files: \n  - %s\n",
+                '\n  - '.join(valid_files),
+            )
+        logger.error(
+            "[bold red]Invalid[/bold red] files: \n  - %s\n",
+            '\n  - '.join(invalid_files),
+        )
+        raise ValueError("One or more schema files are invalid: Please check the logs.")

--- a/src/scicat_kafka.py
+++ b/src/scicat_kafka.py
@@ -49,8 +49,13 @@ def collect_kafka_topics(options: KafkaOptions) -> list[str]:
 def build_consumer(kafka_options: KafkaOptions, logger: logging.Logger) -> Consumer:
     """Build a Kafka consumer and configure it according to the ``options``."""
     consumer_options = collect_consumer_options(kafka_options)
-    logger.info("Connecting to Kafka with the following parameters:")
-    logger.info(consumer_options)
+    logger.info(
+        # `KafkaOptions` has `__str__` dundermethod for logging.
+        # It explicitly choose which configurations can be printed/shown.
+        # DO NOT print/log the whole container since it may contain user credentials.
+        "Connecting to Kafka with the following parameters: %s",
+        str(consumer_options),
+    )
     consumer = Consumer(consumer_options)
     if not validate_consumer(consumer, logger):
         return None
@@ -82,7 +87,7 @@ def _validate_wrdn_message_type(message_content: bytes, logger: logging.Logger) 
         logger.info("WRDN message received.")
         return True
     else:
-        logger.info("Message of type %s ignored", message_type)
+        logger.info("Message of type %s ignored.", message_type)
         return False
 
 
@@ -91,8 +96,8 @@ def _filter_error_encountered(
 ) -> WritingFinished | None:
     """Filter out messages with the ``error_encountered`` flag set to True."""
     if deserialized_message.error_encountered:
-        logger.error(
-            "Unable to deserialize message. ``error_encountered`` is true. Skipping the message."
+        logger.info(
+            "Unable to deserialize message. `error_encountered` is true. Skipping the message."
         )
         return None
     else:
@@ -108,7 +113,12 @@ def _deserialise_wrdn(
         logger.info("Deserialising WRDN message")
         deserialized_message: WritingFinished = deserialise_wrdn(message_content)
         deserialized_message = _filter_error_encountered(deserialized_message, logger)
-        logger.info("Deserialised WRDN message: %.5000s", deserialized_message)
+        logger.info(
+            "Deserialised WRDN message with job id, %s for file %s.",
+            deserialized_message.job_id,
+            deserialized_message.file_name,
+        )
+        logger.debug("Deserialised WRDN message: %.5000s", deserialized_message)
 
     return deserialized_message
 
@@ -120,41 +130,26 @@ def wrdn_messages(
 
     Yield ``None`` if no message is received or an error is encountered.
     """
+    num_skipped = 1
     while True:
         # The decision to proceed or stop will be done by the caller.
-        message = consumer.poll(timeout=1.0)
+        timeout = 1.0
+        message = consumer.poll(timeout=timeout)
         if message is None:
-            logger.info("Received no messages")
+            num_skipped += 1
+            logger.info("Received no messages, %d [s].", timeout * num_skipped)
             yield None
         elif message.error():
+            num_skipped = 1  # Reset
             logger.error("Consumer error: %s", message.error())
             yield None
         else:
+            num_skipped = 1  # Reset
             # retrieve type of message
             message_value = message.value()
             message_type = message_value[4:8]
             logger.info("Received message. Type : %s", message_type)
             yield _deserialise_wrdn(message_value, logger)
-
-
-# def compose_message_path(
-#     *,
-#     target_dir: pathlib.Path,
-#     nexus_file_path: pathlib.Path,
-#     message_saving_options: MessageSavingOptions,
-# ) -> pathlib.Path:
-#     """Compose the message path based on the nexus file path and configuration."""
-#
-#     return target_dir / (
-#         pathlib.Path(
-#             ".".join(
-#                 (
-#                     nexus_file_path.stem,
-#                     message_saving_options.message_file_extension.removeprefix("."),
-#                 )
-#             )
-#         )
-#     )
 
 
 def save_message_to_file(

--- a/src/scicat_metadata.py
+++ b/src/scicat_metadata.py
@@ -1,7 +1,6 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2024 ScicatProject contributors (https://github.com/ScicatProject)
 
-import argparse
 import json
 import logging
 import pathlib
@@ -307,7 +306,7 @@ def _select_applicable_schema(
         if select_target_name in ["filename"]:
             select_target_value = filename
         else:
-            logger.error(
+            logger.warning(
                 "Invalid target name %s. Use one of (%s)",
                 select_target_name,
                 ', '.join(_AVAILABLE_SELECTION_TARGET_NAMES),
@@ -322,7 +321,7 @@ def _select_applicable_schema(
         elif select_function_name == "contains":
             return select_argument in select_target_value
         else:
-            logger.error(
+            logger.warning(
                 "Invalid function name %s. Use one of (%s)",
                 select_function_name,
                 ', '.join(_AVAILBALE_SELECTION_FUNCTION_NAMES),
@@ -343,14 +342,14 @@ def _select_applicable_schema(
                     for item in conditions
                 )
             else:
-                logger.error(
+                logger.warning(
                     "Invalid condition operator name: %s. Use one of (%s)",
                     key,
                     ', '.join(_AVAILABLE_OPERATOR_NAMES),
                 )
         return output
     else:
-        logger.error("Invalid type for schema selector %s", type(selector))
+        logger.warning("Invalid type for schema selector %s.", type(selector))
 
     return False
 
@@ -377,193 +376,9 @@ def select_applicable_schema(
             "no fallback schema is given. Cannot determine the schema..."
         )
 
-    logger.error(
+    logger.warning(
         "No applicable metadata schema found based on the selectors. "
         "Fallback schema will be used..."
     )
 
     return fall_back_schema
-
-
-def _parse_args() -> argparse.Namespace:
-    arg_parser = argparse.ArgumentParser(
-        description="Validate the metadata schema files."
-    )
-    arg_parser.add_argument(
-        type=str,
-        help="Schema file/directory path (imsc) to validate. If a directory is passed, "
-        "all schema files in the directory will be validated.",
-        dest="schema_file",
-    )
-    return arg_parser.parse_args()
-
-
-def _collect_target_files(
-    schema_file: pathlib.Path, logger: logging.Logger
-) -> list[pathlib.Path]:
-    if not schema_file.exists():
-        raise FileNotFoundError(f"Schema file(location) {schema_file} does not exist.")
-    elif schema_file.is_dir():
-        logger.info("Collecting schema files from the directory `%s`...", schema_file)
-        schema_files = list_schema_file_names(schema_file)
-        if not schema_files:
-            raise FileNotFoundError(
-                f"No schema files found in the directory {schema_file}."
-            )
-        file_list = '\n - '.join([file_path.name for file_path in schema_files])
-        logger.info("Found %d schema files.\n - %s", len(schema_files), file_list)
-    else:
-        schema_files = [schema_file]
-
-    return schema_files
-
-
-def _validate_mandatory_machine_names(
-    schema: MetadataSchema, file_name: str, logger: logging.Logger
-) -> bool:
-    MANDATORY_MACHINE_NAMES = {
-        'datasetName',
-        'principalInvestigator',
-        'creationLocation',
-        'owner',
-        'ownerEmail',
-        'sourceFolder',
-        'contactEmail',
-        'creationTime',
-    }
-    machine_names = {field.machine_name for field in schema.schema.values()}
-    if not MANDATORY_MACHINE_NAMES.issubset(machine_names):
-        missing = MANDATORY_MACHINE_NAMES - machine_names
-        logger.error(
-            "Schema file [red]%s[/red] is missing mandatory fields: [yellow]%s[/yellow]",
-            file_name,
-            '[/yellow], [yellow]'.join(missing),
-        )
-        return False
-
-    logger.info("All mandatory [green]machine names[/green] found.")
-    return True
-
-
-def _validate_schema_selector(selector: str | dict, logger: logging.Logger) -> bool:
-    if isinstance(selector, str):
-        if len(selector.split(":")) != 3:
-            logger.error(
-                "Invalid selector format: '[yellow]%s[/yellow]' "
-                "Selector should be <bold>field:fiter_type:value</bold>",
-                selector,
-            )
-            return False
-    elif isinstance(selector, dict):
-        for conditions in selector.values():
-            return all(_validate_schema_selector(item, logger) for item in conditions)
-
-    logger.info("All [green]schema selector[/green] validated.")
-    return True
-
-
-def _validate_schema_item_config_type(
-    metadata_item_configs: dict[str, MetadataItemConfig], logger: logging.Logger
-) -> bool:
-    invalid_types = [
-        field.field_type
-        for field in metadata_item_configs.values()
-        if field.field_type not in VALID_METADATA_TYPES
-    ]
-
-    if any(invalid_types):
-        logger.error(
-            "Invalid metadata schema types found: %s .\nValid types are: %s. "
-            "Metadata items with invalid types will be ignored.",
-            VALID_METADATA_TYPES,
-            invalid_types,
-        )
-        return False
-
-    return True
-
-
-def _validate_file(schema_file: pathlib.Path, logger: logging.Logger) -> bool:
-    logger.info(
-        "Checking schema file: [bold purple]%s [/bold purple]", schema_file.name
-    )
-    # Check if it is a json file
-    if _is_json_file(schema_file.read_text()):
-        logger.warning(
-            "Schema file [yellow]%s[/yellow] is in "
-            "[bold yellow]JSON[/bold yellow] format. "
-            "It is recommended to use [bold yellow]YAML[/bold yellow] format for new schema files.",
-            schema_file,
-        )
-        return False
-    # Try building the `MetadataSchema` from the file.
-    try:
-        schema = MetadataSchema.from_file(schema_file)
-        msg = "Schema file [green]%s[/ green] has [bold green]VALID[/bold green] structure."
-        logger.info(msg, schema_file.name)
-    except Exception as e:
-        msg = "Schema file [red]%s[/red] is [bold red]INVALID[/bold red]: %s"
-        logger.error(msg, schema_file.name, e)
-        return False
-
-    return (
-        # Validate schema
-        # Manually check mandatory machine names
-        # They are part of fields of `scicat_dataset.ScicatDataset` dataclass.
-        # Some of the mandatory arguments are not filled by schema definition.
-        _validate_mandatory_machine_names(schema, schema_file.name, logger)
-        and _validate_schema_selector(schema.selector, logger)
-        # Validate item type config. It's a free field but should be one of valid types.
-        and _validate_schema_item_config_type(schema.schema, logger)
-    )
-
-
-def validate_schema(
-    *, schema_path: pathlib.Path | None = None, logger: logging.Logger | None = None
-) -> None:
-    """Validate the schema file."""
-    from scicat_logging import build_devtool_logger
-
-    if schema_path is None:
-        # Parse command line arguments
-        args = _parse_args()
-        schema_path = pathlib.Path(args.schema_file)
-
-    if logger is None:
-        # Build a logger
-        logger = build_devtool_logger("validate-schema-file")
-
-    logger.info("Scicat ingestor metadata schema files validation test.")
-    logger.info("It only validates if the schema file has a valid structure.")
-
-    # Collect schema files
-    schema_files = _collect_target_files(schema_path, logger)
-    if not schema_files:
-        raise ValueError("No schema file found to validate.")
-
-    logger.info("Validating %d schema files...", len(schema_files))
-
-    # Collect validities of all files first
-    # to avoid stopping on the first invalid file.
-    validities = {
-        schema_file.name: _validate_file(schema_file, logger)
-        for schema_file in schema_files
-    }
-    if all(validities.values()):
-        logger.info(
-            "All schema files,\n  - %s\nare [bold green]VALID[/bold green].",
-            '\n  - '.join(validities.keys()),
-        )
-    else:
-        invalid_files = {k for k, _ in filter(lambda kv: not kv[1], validities.items())}
-        valid_files = set(validities.keys()) - invalid_files
-        if valid_files:
-            logger.info(
-                "[bold green]Valid[/bold green] files: \n  - %s\n",
-                '\n  - '.join(valid_files),
-            )
-        logger.error(
-            "[bold red]Invalid[/bold red] files: \n  - %s\n",
-            '\n  - '.join(invalid_files),
-        )
-        raise ValueError("One or more schema files are invalid: Please check the logs.")

--- a/src/scicat_offline_ingestor.py
+++ b/src/scicat_offline_ingestor.py
@@ -220,11 +220,7 @@ def main() -> None:
     config = build_offline_config(logger=logger)
     fh_options = config.ingestion.file_handling
 
-    # Log the configuration as dictionary so that it is easier to read from the logs
-    logger.info(
-        'Starting the Scicat background Ingestor with the following configuration: %s',
-        config.to_dict(),
-    )
+    logger.info('Starting the Scicat background Ingestor.')
 
     # Collect all metadata schema configurations
     schemas = collect_schemas(config.ingestion.schemas_directory)
@@ -296,7 +292,7 @@ def main() -> None:
         schema_definitions = {**fallback_schema_definitions, **metadata_schema.schema}
 
         # Prepare scicat dataset instance(entry)
-        logger.info("Preparing scicat dataset instance ...")
+        logger.info("Preparing scicat dataset instance.")
         local_dataset_instance = create_scicat_dataset_instance(
             metadata_schema=schema_definitions,
             variable_map=variable_map,
@@ -357,8 +353,8 @@ def main() -> None:
             # check one more time if we successfully created the entries in scicat
             if not ((len(scicat_dataset) > 0) and (len(scicat_origdatablock) > 0)):
                 logger.error(
-                    "Failed to create dataset or origdatablock in scicat for file %s.\n"
-                    "SciCat dataset: %s\nSciCat origdatablock: %s",
+                    "Failed to create dataset or origdatablock in scicat for file %s. "
+                    "SciCat dataset: %s, SciCat origdatablock: %s",
                     nexus_file_path,
                     scicat_dataset,
                     scicat_origdatablock,
@@ -369,10 +365,10 @@ def main() -> None:
 
             # if we get here, both dataset and origdatablock have been created successfully
             logger.info(
-                "Dataset ingestion successful. \n"
-                "Data file: %s. \n"
-                "Scicat dataset pid: %s. \n"
-                "SciCat origdatablock id: %s",
+                "Dataset ingestion successful. "
+                "Data file: %s, "
+                "Scicat dataset pid: %s, "
+                "SciCat origdatablock id: .",
                 nexus_file_path,
                 scicat_dataset.get('pid'),
                 scicat_origdatablock.get('_id'),

--- a/src/scicat_online_ingestor.py
+++ b/src/scicat_online_ingestor.py
@@ -50,15 +50,17 @@ def dump_message_to_file_if_needed(
         logger.info("Message saving to file is disabled. Skipping saving message.")
         return
     elif not message_file_path.parent.exists():
-        logger.info("Message file directory not accessible. Skipping saving message.")
+        logger.warning(
+            "Message file directory not accessible. Skipping saving message."
+        )
         return
 
-    logger.info("Message will be saved in %s", message_file_path)
+    logger.info("Message will be saved in %s.", message_file_path)
     save_message_to_file(
         message=message,
         message_file_path=message_file_path,
     )
-    logger.info("Message file saved")
+    logger.info("Message file saved.")
 
 
 def _individual_message_commit(job_id, message, consumer, logger: logging.Logger):
@@ -117,9 +119,7 @@ def main() -> None:
     logger = build_logger(tmp_config)
     config = build_online_config(logger=logger)
 
-    # Log the configuration as dictionary so that it is easier to read from the logs
-    logger.info('Starting the Scicat online Ingestor with the following configuration:')
-    logger.info(config.to_dict())
+    logger.info('Starting the Scicat online Ingestor.')
 
     with handle_daemon_loop_exceptions(logger=logger):
         # Kafka consumer
@@ -183,7 +183,7 @@ def main() -> None:
                         done_writing_message_file_path,
                     ]
 
-                logger.info("Command to be run: \n\n%s\n\n", cmd)
+                logger.info("Command to be run: %s", ' '.join(cmd))
                 if config.ingestion.dry_run:
                     logger.info("Dry run mode enabled. Skipping background ingestor.")
                 else:

--- a/src/system_helpers.py
+++ b/src/system_helpers.py
@@ -9,7 +9,7 @@ def exit(logger: logging.Logger, unexpected: bool = True) -> None:
     """Log the message and exit the program."""
     import sys
 
-    logger.info("Exiting ingestor")
+    logger.info("Exiting ingestor.")
     sys.exit(1 if unexpected else 0)
 
 
@@ -56,9 +56,9 @@ def handle_daemon_loop_exceptions(
         logger.info("Received keyboard interrupt.")
         exit(logger, unexpected=False)
     except ignored_exceptions as ignored_err:
-        logger.error(
+        logger.warning(
             "An exception occurred, "
-            "but it is in the ignored list: %s \n. Ignored exception is: %s",
+            "but it is in the ignored list: %s . Ignored exception is: %s",
             ignored_exceptions,
             ignored_err,
         )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -68,7 +68,7 @@ def example_schema() -> MetadataSchema:
 
     import yaml
 
-    from scicat_metadata import _validate_file
+    from scicat_devtools import _validate_file
 
     # Turn this yaml string into a stream
     _example_schema = (

--- a/tests/test_scicat_config.py
+++ b/tests/test_scicat_config.py
@@ -1,3 +1,4 @@
+import re
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -48,7 +49,9 @@ def test_config_validator(template_config_file: Path) -> None:
 
 
 def test_config_validator_json_file_warns() -> None:
-    with pytest.warns(DeprecationWarning, match="deprecated. Please use YAML format"):
+    with pytest.warns(
+        DeprecationWarning, match=re.escape("deprecated. Please use YAML format")
+    ):
         _validate_config_file(
             OnlineIngestorConfig,
             Path(__file__).parent / "resources/legacy_json_config.json",
@@ -56,7 +59,9 @@ def test_config_validator_json_file_warns() -> None:
 
 
 def test_config_validator_unused_args_raises() -> None:
-    with pytest.raises(ValueError, match="Invalid argument found: \n\t\t- config_file"):
+    with pytest.raises(
+        ValueError, match=re.escape("Invalid argument found: config_file")
+    ):
         _validate_config_file(
             DummyConfig,
             Path(__file__).parent / "resources/invalid_config.yml",

--- a/tests/test_scicat_metadata_schema.py
+++ b/tests/test_scicat_metadata_schema.py
@@ -9,6 +9,7 @@ import yaml
 
 from fallback_metadata_schema import get_fallback_schema
 from scicat_configuration import OfflineIngestorConfig
+from scicat_devtools import validate_schema
 from scicat_metadata import (
     MetadataSchema,
     MetadataVariableValueSpec,
@@ -16,7 +17,6 @@ from scicat_metadata import (
     collect_schemas,
     list_schema_file_names,
     select_applicable_schema,
-    validate_schema,
 )
 
 ALL_SCHEMA_EXAMPLES = list_schema_file_names(
@@ -192,7 +192,7 @@ def test_metadata_schema_selection_contains_no_match_log_error(
         "No applicable metadata schema found based on the selectors. "
         "Fallback schema will be used..."
     )
-    assert fake_logger._error_list[-1].msg == err_msg_match
+    assert fake_logger._warning_list[-1].msg == err_msg_match
 
 
 def test_metadata_schema_selection_contains_no_match_fallback(
@@ -235,7 +235,7 @@ def test_metadata_schema_selection_wrong_selector_target_log_error(
     # The wrong target name error message should be the second last one.
     # It is not to enforce the order of logging so feel free to change
     # how it is tested if it becomes too brittle.
-    assert fake_logger._error_list[-2].msg.startswith(err_msg_match)
+    assert fake_logger._warning_list[-2].msg.startswith(err_msg_match)
 
 
 def test_metadata_schema_selection_wrong_selector_function_log_error(
@@ -265,7 +265,7 @@ def test_metadata_schema_selection_wrong_selector_function_log_error(
     # The wrong target name error message should be the second last one.
     # It is not to enforce the order of logging so feel free to change
     # how it is tested if it becomes too brittle.
-    assert fake_logger._error_list[-2].msg.startswith(err_msg_match)
+    assert fake_logger._warning_list[-2].msg.startswith(err_msg_match)
 
 
 def test_metadata_variable_default_variables(


### PR DESCRIPTION
From the comments at https://github.com/SciCatProject/scicat-ingestor/pull/216#pullrequestreview-3980508670

- Remove logging configuration that potentially contains tokens or credentials
- Remove multi-lines and markers from the logging messages
- Use json/as_dict for dictionary-like object logging
- Use `warning` instead `error` for non-critical errors
- Separate developer's tools from the `scicat_metadata` module