### PR TITLE
feat: Add Docker image build and release workflow

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,32 @@
+# Version control
+.git/
+.gitignore
+.gitattributes
+
+# Development tools
+.venv/
+.pixi/
+.pre-commit-config.yaml
+pixi.toml
+pixi.lock
+
+# Build artifacts
+__pycache__/
+**/__pycache__/
+*.pyc
+*.pyo
+*.pyd
+**/*.egg-info/
+dist/
+build/
+*.egg
+
+# Tests and test data
+tests/
+test-data/
+
+# Documentation
+documentation/
+
+# Config samples (runtime config must be mounted, not baked in)
+resources/

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -1,0 +1,91 @@
+name: Build and Push Docker Image
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'PEP 440 version to embed in the image (e.g. 1.2.3). Defaults to 0.0.0.'
+        required: false
+        default: '0.0.0'
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  test:
+    name: Tests
+    uses: ./.github/workflows/test.yml
+    with:
+      os-variant: 'ubuntu-24.04'
+
+  build-and-push:
+    name: Build and Push Docker Image
+    runs-on: ubuntu-24.04
+    needs: test
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          # Full history is required so that setuptools_scm can derive the version
+          # from the git tag. The SETUPTOOLS_SCM_PRETEND_VERSION build-arg is used
+          # as an explicit fallback so the build never fails due to missing tags.
+          fetch-depth: 0
+
+      - name: Derive PEP 440 version from release tag
+        id: version
+        run: |
+          if [[ "${{ github.event_name }}" == "release" ]]; then
+            FULL_VERSION="${{ github.event.release.tag_name }}"
+          else
+            FULL_VERSION="v${{ inputs.version }}"
+          fi
+          # Strip the leading 'v' so the version is PEP 440 compatible (e.g. 1.2.3).
+          PEP440="${FULL_VERSION#v}"
+          echo "full=${FULL_VERSION}" >> "$GITHUB_OUTPUT"
+          echo "pep440=${PEP440}" >> "$GITHUB_OUTPUT"
+
+      - name: Set up QEMU (for cross-platform builds)
+        uses: docker/setup-qemu-action@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract Docker metadata (tags and labels)
+        id: meta
+        uses: docker/metadata-action@v6
+        with:
+          images: ghcr.io/scicatproject/scicat-ingestor
+          tags: |
+            # e.g. 1.2.3
+            type=semver,pattern={{version}}
+            # e.g. 1.2
+            type=semver,pattern={{major}}.{{minor}}
+            # e.g. 1
+            type=semver,pattern={{major}}
+            # 'latest' only for non-pre-releases
+            type=raw,value=latest,enable=${{ github.event.release.prerelease == false }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          push: true
+          platforms: linux/amd64,linux/arm64
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            VERSION=${{ steps.version.outputs.pep440 }}
+          # GitHub Actions cache keeps subsequent builds fast.
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,46 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2024 ScicatProject contributors (https://github.com/ScicatProject)
+
+# ---- Build stage ----
+FROM python:3.12-slim AS builder
+
+ARG VERSION=0.0.0
+
+WORKDIR /build
+
+RUN pip install --no-cache-dir --upgrade pip
+
+COPY pyproject.toml README.md LICENSE ./
+COPY src/ ./src/
+
+ENV SETUPTOOLS_SCM_PRETEND_VERSION=${VERSION}
+
+RUN python -m venv /opt/venv && \
+    /opt/venv/bin/pip install --no-cache-dir ".[app]"
+
+# ---- Final stage ----
+FROM python:3.12-slim
+
+LABEL org.opencontainers.image.title="SciCat Ingestor" \
+    org.opencontainers.image.description="A daemon that creates SciCat datasets whenever a new file is written by a file-writer." \
+    org.opencontainers.image.source="https://github.com/ScicatProject/scicat-ingestor" \
+    org.opencontainers.image.licenses="BSD-3-Clause"
+
+RUN groupadd --system ingestor && \
+    useradd --system --gid ingestor --create-home --shell /sbin/nologin ingestor
+
+COPY --from=builder /opt/venv /opt/venv
+
+ENV PATH="/opt/venv/bin:$PATH"
+
+# Health check polls the built-in /health endpoint exposed by the online ingestor.
+HEALTHCHECK --interval=30s --timeout=10s --start-period=30s --retries=3 \
+    CMD python -c "import urllib.request; urllib.request.urlopen('http://localhost:8080/health')" || exit 1
+
+USER ingestor
+
+# Health check HTTP server port (configurable via config file).
+EXPOSE 8080
+
+ENTRYPOINT ["scicat_ingestor"]
+CMD ["--config-file", "/config/config.yml"]

--- a/src/scicat_online_ingestor.py
+++ b/src/scicat_online_ingestor.py
@@ -8,8 +8,10 @@ import pathlib
 import subprocess
 from time import sleep
 
+PACKAGE_NAME = "scicat-ingestor"
+
 try:
-    __version__ = importlib.metadata.version(__package__ or __name__)
+    __version__ = importlib.metadata.version(PACKAGE_NAME)
 except importlib.metadata.PackageNotFoundError:
     __version__ = "0.0.0"
 
@@ -119,7 +121,7 @@ def main() -> None:
     logger = build_logger(tmp_config)
     config = build_online_config(logger=logger)
 
-    logger.info('Starting the Scicat online Ingestor.')
+    logger.info('Starting the Scicat online Ingestor. Version: %s', __version__)
 
     with handle_daemon_loop_exceptions(logger=logger):
         # Kafka consumer


### PR DESCRIPTION
This adds initial Docker support for scicat-ingestor and wires container image publishing into GitHub releases.
When a new GitHub release is published, the workflow builds and pushes a Docker image. The application version is derived from the release tag during the image build and is logged at startup.